### PR TITLE
Updated timepicker with better default values

### DIFF
--- a/src/app/panels/timepicker/module.js
+++ b/src/app/panels/timepicker/module.js
@@ -61,13 +61,13 @@ function (angular, app, _, moment, kbn, $) {
       switch($scope.panel.mode) {
       case 'absolute':
         $scope.time = {
-          from : moment($scope.panel.time.from,'MM/DD/YYYY HH:mm:ss') || moment(kbn.time_ago($scope.panel.timespan)),
+          from : moment(kbn.time_ago($scope.panel.timespan)),
           to   : moment($scope.panel.time.to,'MM/DD/YYYY HH:mm:ss') || moment()
         };
         break;
       case 'since':
         $scope.time = {
-          from : moment($scope.panel.time.from,'MM/DD/YYYY HH:mm:ss') || moment(kbn.time_ago($scope.panel.timespan)),
+          from : moment(kbn.time_ago($scope.panel.timespan)),
           to   : moment()
         };
         break;


### PR DESCRIPTION
Based on my experience, the default date range wasn't used if the default was absolute or since mode in the timepicker, especially if user visited the dashboard before. This will set the default "from" time to be whatever is in the configuration of the timepicker on subsequent banana visits as well.
