### PR TITLE
For the Histogram panel, if Time Correction is set to UTC or Browser, it doesn’t reflect on tooltip, Tooltip always shows Browser mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,23 @@ Pull the repo from the "release" branch; version 1.4 will be tagged as banana-1.
 
 ## Banana 1.4: Released on 15 September 2014
 
-Banana 1.4 contains many new features, new panels, enhancements and bug fixes to improve the overall experience and stability. Thank you our communities for all the contributions! Please keep sending us feedbacks and suggestions so we can continue to improve Banana!
+Banana 1.4 contains many new features, new panels, enhancements and bug fixes to improve the overall user experience and stability. Thank you to our growing community for your suggestions and contributions! Please continue sending us your feedbacks, so that we can further extend and improve Banana!
 
-Key new features and improvements in this release are the followings:
+This release includes the following key new features and improvements:
 
-1. Performance optimization by better utilizing Solr's caches in _Timepicker Module_ with Relative time mode or Since time mode.
-2. A new _Full Text Search_ panel allows you to visualize your non time-series data with faceting and highlighting capabilities of Solr.
-3. New features and enhancements in _Table_ panel:
-    * Sorting option can be turned off in order to speed up the search results returned from Solr.
-    * A table column can be set as hyperlink column so that its values will be clickable and linked to URIs.
-    * Display images inside a table column.
-4. Improvement in _Range Facet_ panel with the ability to set the chart's precision automatically or manually.
-5. In _Terms_ panel, the chart colors can be customized by changing the default color template or using field values as colors.
-6. Allow loading and saving dashboard to Gist.
-7. Fix Solr server location for banana-int collection. Now banana-int should be located on the same Solr server as specified in Solr Settings in the Dashboard configuration. You do not have to manually edit config.js file anymore.
-8. New button on the dashboard to quickly create a new dashboard from templates. Currently, we provide two default templates: Time-series dashboard and Non time-series dashboard.
-9. _Histogram_ panel will not require time field in the setting anymore, because it will use the same time field from the _Filtering_ panel.
-10. *Usability enhancement* to all panels by allowing you to specifying custom help messages inside each panel without needing to use _Text_ panel. So now you can embed any information or instructions for each panel in the dashboard to better communicate with your users.
+1. Banana 1.4 provides much improved performance - by better utilizing Solr's caches in _Timepicker Module_. This improvement is discernable in the Relative and Since time modes.
+2. A new _Full Text Search_ panel provides a more traditional search interface to view textual data.
+3. Enhancements to the _Table_ panel improve performance and user experience:
+    * Sorting option can now be turned off in order to speed up the search results returned from Solr.
+    * A particular column - corresponding to a URI field - can be set as the hyperlink column. When set, this value will become clickable and linked to a specific URI.
+    * You can now display images inside a table column.
+4. In the _Range Facet_ panel, users now have the ability to set the chart's precision automatically or manually.
+5. In the _Terms_ panel, chart colors can be customized by changing the default color template or by using field values as colors.
+6. It is now possible to load and save a dashboard to Gist.
+7. We have fixed the Solr server location for the banana-int collection, the internal collection that stores dashboards. Now banana-int should be located on the same Solr server as specified in Solr Settings in the Dashboard configuration. You do not have to manually edit config.js file anymore.
+8. The dashboard contains a new button that enables users to quickly create a new dashboard from templates. Currently, we provide two default templates: a time-series dashboard template and a non time-series one.
+9. The _Histogram_ panel no longer requires you to set a time field; as logically expected, it will get the time field from the _Timepicker_ panel.
+10. We have enhanced the usability by allowing you to specify custom help messages inside each panel. You no longer need to use a separate _Text_ panel for this purpose. Instead, you can now embed information and instructions within each panel in the dashboard to better communicate with your users.
 
 ## Banana 1.3: Released on 10 June 2014
 

--- a/src/app/dashboards/default-nts.json
+++ b/src/app/dashboards/default-nts.json
@@ -54,6 +54,7 @@
           "pinned": true,
           "query": "*",
           "title": "Search",
+          "spyable": true,
           "def_type": ""
         },
         {
@@ -95,6 +96,7 @@
           "error": false,
           "span": 5,
           "editable": true,
+          "spyable": true,
           "group": [
             "default"
           ],

--- a/src/app/dashboards/default-ts.json
+++ b/src/app/dashboards/default-ts.json
@@ -84,6 +84,7 @@
             "min": 3
           },
           "filter_id": 0,
+          "spyable": true,
           "title": "Time Window"
         },
         {
@@ -100,6 +101,7 @@
           "pinned": true,
           "query": "*:*",
           "title": "Search",
+          "spyable": true,
           "def_type": ""
         },
         {
@@ -141,6 +143,7 @@
           "error": false,
           "span": 12,
           "editable": true,
+          "spyable": true,
           "group": [
             "default"
           ],

--- a/src/app/dashboards/default.json
+++ b/src/app/dashboards/default.json
@@ -86,7 +86,6 @@
       "editable": true,
       "collapse": false,
       "collapsable": true,
-      "spyable" : true,
       "panels": [
         {
           "error": "",

--- a/src/app/panels/query/editor.html
+++ b/src/app/panels/query/editor.html
@@ -1,6 +1,1 @@
-<div class="span2" ng-show="!_.isUndefined(panel.spyable)">
-    <label class="small">
-        Inspect <i class="icon-question-sign" bs-tooltip="'Allow query reveal via <i class=icon-eye-open></i>'"></i>
-    </label>
-    <input type="checkbox" ng-model="panel.spyable" ng-checked="panel.spyable">
-</div>
+Nothing to Configure Here.


### PR DESCRIPTION
Origin Banana Implementation
 $tooltip
              .html(
                group + dashboard.numberWithCommas(value) + " @ " + moment(item.datapoint[0]).format('MM/DD HH:mm:ss')
              )
              .place_tt(pos.pageX, pos.pageY);

Changed implementation
 var tooltipTime = moment(item.datapoint[0]).format('MM/DD HH:mm:ss');
              if(scope.panel.timezone === 'utc') {
                  tooltipTime = moment.utc(item.datapoint[0]).format('MM/DD HH:mm:ss');
              }
            $tooltip
              .html(
                group + dashboard.numberWithCommas(value) + " @ " + tooltipTime
              )
