### PR TITLE
Panel / Terms / Add log axis.

### DIFF
--- a/src/app/panels/terms/editor.html
+++ b/src/app/panels/terms/editor.html
@@ -55,6 +55,9 @@
   <div class="span1" ng-show="panel.chart == 'pie'">
     <label class="small">Labels</label><input type="checkbox" ng-model="panel.labels" ng-checked="panel.labels">
   </div>
+  <div class="span1" ng-show="panel.chart == 'bar'">
+    <label class="small">Log axis</label><input type="checkbox" ng-model="panel.logAxis" ng-checked="panel.logAxis">
+  </div>
 </div>
 <div class="row-fluid">
   <div class="span2">

--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -62,6 +62,7 @@ function (angular, app, _, $, kbn) {
       donut   : false,
       tilt    : false,
       labels  : true,
+      logAxis : false,
       arrangement : 'horizontal',
       chart       : 'bar',
       counter_pos : 'above',
@@ -318,15 +319,43 @@ function (angular, app, _, $, kbn) {
             try {
               // Add plot to scope so we can build out own legend
               if(scope.panel.chart === 'bar') {
+
+                var yAxisConfig = {
+                  show: true,
+                  min: scope.yaxis_min,
+                  color: "#c8c8c8"
+                };
+                if (scope.panel.logAxis) {
+                  _.defaults(yAxisConfig, {
+                    ticks: function (axis) {
+                      var res = [], i = 1,
+                        ticksNumber = 8,
+                        max = axis.max === 0 ? 0 : Math.log(axis.max),
+                        min = axis.min === 0 ? 0 : Math.log(axis.min),
+                        interval = (max - min) / ticksNumber;
+                      do {
+                        var v = interval * i;
+                        res.push(Math.exp(v));
+                        ++i;
+                      } while (v < max);
+                      return res;
+                    },
+                    transform: function (v) {
+                      return v === 0 ? 0 : Math.log(v); },
+                    inverseTransform: function (v) {
+                      return v === 0 ? 0 : Math.exp(v); }
+                  });
+                }
+
                 plot = $.plot(elem, chartData, {
                   legend: { show: false },
                   series: {
-                    lines:  { show: false, },
+                    lines:  { show: false },
                     bars:   { show: true,  fill: 1, barWidth: 0.8, horizontal: false },
                     shadowSize: 1
                   },
                   // yaxis: { show: true, min: 0, color: "#c8c8c8" },
-                  yaxis: { show: true, min: scope.yaxis_min, color: "#c8c8c8" },
+                  yaxis: yAxisConfig,
                   xaxis: { show: false },
                   grid: {
                     borderWidth: 0,
@@ -354,7 +383,7 @@ function (angular, app, _, $, kbn) {
 
                 plot = $.plot(elem, chartData, {
                   legend: {
-                    show: false,
+                    show: false
                     // position: position,
                     // backgroundColor: "transparent"
                   },


### PR DESCRIPTION
In some cases, it may be relevant to provide the capability to have log axis for better readability.

Example:

![image](https://cloud.githubusercontent.com/assets/1701393/4717390/4e86884a-5914-11e4-8d0b-e390dd3212f8.png)

Configuration in the panel options for bar charts:

![image](https://cloud.githubusercontent.com/assets/1701393/4717386/431a0694-5914-11e4-97f9-50c443987102.png)

Bar chart with log axis:

![image](https://cloud.githubusercontent.com/assets/1701393/4717384/34eff164-5914-11e4-8b9d-fca82187bd54.png)

Also fixed some unneeded extra-comma.
