### PR TITLE
Build / Fix jshint error during build

### DIFF
--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -329,13 +329,13 @@ function (angular, app, _, $, kbn) {
                 if (scope.panel.logAxis) {
                   _.defaults(yAxisConfig, {
                     ticks: function (axis) {
-                      var res = [], i = 1,
+                      var res = [], v, i = 1,
                         ticksNumber = 8,
                         max = axis.max === 0 ? 0 : Math.log(axis.max),
                         min = axis.min === 0 ? 0 : Math.log(axis.min),
                         interval = (max - min) / ticksNumber;
                       do {
-                        var v = interval * i;
+                        v = interval * i;
                         res.push(Math.exp(v));
                         ++i;
                       } while (v < max);


### PR DESCRIPTION
Related to 26a50ea9eac5a78096eca269abcd8635c0ece580

Error was:

```
src/app/panels/terms/module.js
341 | } while (v < max);
               ^ 'v' used out of scope.
```
