### PR TITLE
Update module.js

### DIFF
--- a/src/app/panels/facet/module.js
+++ b/src/app/panels/facet/module.js
@@ -60,7 +60,7 @@ define([
         foundResults: true,
         header_title: "Limit Your Search",
         toggle_element: null,
-        spyable: true,
+        //spyable: true, // Removed. Duplicate data property in object literal not allowed in strict mode
       };
       _.defaults($scope.panel, _d);
 


### PR DESCRIPTION
Duplicate data property in object literal not allowed in strict mode.

I had also same problem with 1.4 version (https://github.com/LucidWorks/banana)
I checked it again. And I found new errors. I never modified source codes.
1.  git clone https://github.com/LucidWorks/banana (branch: release)
2.  Build with ant from $BANANA_HOME
3.  Deploy banana-0.war to $SOLR_HOME/example/webapps/
4. Execute Java -jar start.jar
5. Change solr url
6. Add 'facet' panel
7. Show the error messages
   module.js:63 Uncaught SyntaxError: Duplicate data property in object literal not allowed in strict mode
   Error: Argument 'facet' is not a function, got undefined
8. Modify $BANANA_HOME/app/panels/facet/module.js
9. Re-build and deploy to solr webapps
10. Success and finished

Could you check the errors again?
