### PR TITLE
Null in facet means missing ?

### DIFF
--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -122,11 +122,11 @@ function (angular, app, _, $, kbn) {
       var facet = '';
 
       if ($scope.panel.mode === 'count') {
-        facet = '&facet=true&facet.field=' + $scope.panel.field + '&facet.limit=' + $scope.panel.size + '&facet.missing=true';
+        facet = '&facet=true&facet.field=' + $scope.panel.field + '&facet.limit=' + $scope.panel.size + '&facet.missing=' + $scope.panel.missing;
       } else {
         // if mode != 'count' then we need to use stats query
         // stats does not support something like facet.limit, so we have to sort and limit the results manually.
-        facet = '&stats=true&stats.facet=' + $scope.panel.field + '&stats.field=' + $scope.panel.stats_field + '&facet.missing=true';;
+        facet = '&stats=true&stats.facet=' + $scope.panel.field + '&stats.field=' + $scope.panel.stats_field + '&facet.missing='  + $scope.panel.missing;
       }
       
       var exclude_length = $scope.panel.exclude.length; 
@@ -182,7 +182,6 @@ function (angular, app, _, $, kbn) {
 
         var sum = 0;
         var k = 0;
-        var missing =0;
         $scope.panelMeta.loading = false;
         $scope.hits = results.response.numFound;
         $scope.data = [];
@@ -196,11 +195,15 @@ function (angular, app, _, $, kbn) {
               i++;
               var count = v[i];
               sum += count;
-              if(term === null)
-                missing = count;
+
               // if count = 0, do not add it to the chart, just skip it
               if (count === 0) { continue; }
-              var slice = { label : term, data : [[k,count]], actions: true};
+              var slice = {
+                label: (term || 'No value'),
+                meta: (term ? '' : 'missing'),
+                data: [[k,count]],
+                actions: true
+              };
               slice = addSliceColor(slice,term);
               $scope.data.push(slice);
             }
@@ -227,10 +230,6 @@ function (angular, app, _, $, kbn) {
           k++;
         });
 
-        $scope.data.push({label:'Missing field',
-          // data:[[k,results.facets.terms.missing]],meta:"missing",color:'#aaa',opacity:0});
-          // TODO: Hard coded to 0 for now. Solr faceting does not provide 'missing' value.
-          data:[[k,missing]],meta:"missing",color:'#aaa',opacity:0});
         $scope.data.push({label:'Other values',
           // data:[[k+1,results.facets.terms.other]],meta:"other",color:'#444'});
           // TODO: Hard coded to 0 for now. Solr faceting does not provide 'other' value. 
@@ -277,9 +276,6 @@ function (angular, app, _, $, kbn) {
       if(term.meta === 'other' && !$scope.panel.other) {
         return false;
       }
-      if(term.meta === 'missing' && !$scope.panel.missing) {
-        return false;
-      }
       return true;
     };
 
@@ -310,8 +306,6 @@ function (angular, app, _, $, kbn) {
 
           // Make a clone we can operate on.
           chartData = _.clone(scope.data);
-          chartData = scope.panel.missing ? chartData :
-            _.without(chartData,_.findWhere(chartData,{meta:'missing'}));
           chartData = scope.panel.other ? chartData :
           _.without(chartData,_.findWhere(chartData,{meta:'other'}));
 


### PR DESCRIPTION
I'm not sure if this depends on the Solr version, but in my case, missing and null values are the same.

A facet query return an item with a null name depending on the facet.missing parameter.

```
<lst name="inspireAnnex">
<int name="ii">51</int>
<int name="i">26</int>
<int name="iii">21</int>
<int>48</int>
</lst>
```

Currently, the missing are added based on the total minus the total of items and a null category is displayed on the charts:
![image](https://cloud.githubusercontent.com/assets/1701393/5440151/41a3f278-8486-11e4-8f2a-cb8058736920.png)

When the missing option is on, we should probably use the facet.missing parameter and rely on the response content for the no value item ?
![image](https://cloud.githubusercontent.com/assets/1701393/5440159/4f7b9fb8-8486-11e4-925e-35e562907f56.png)
