### PR TITLE
Filter panel / Initialize filters from q parameter in location.

### DIFF
--- a/src/app/panels/filtering/module.js
+++ b/src/app/panels/filtering/module.js
@@ -14,7 +14,7 @@ function (angular, app, _) {
   var module = angular.module('kibana.panels.filtering', []);
   app.useModule(module);
 
-  module.controller('filtering', function($scope, filterSrv, $rootScope, dashboard) {
+  module.controller('filtering', function($scope, filterSrv, $rootScope, $location, dashboard) {
 
     $scope.panelMeta = {
       modals: [{
@@ -35,6 +35,23 @@ function (angular, app, _) {
 
     $scope.init = function() {
       $scope.filterSrv = filterSrv;
+
+      var locationSearch = $location.search(),
+          mandateMap = {'+': 'must', '-': 'mustNot'}
+      if (locationSearch.q) {
+        angular.forEach(locationSearch.q.split(' '), function (value) {
+          if (value) {
+            var startWithMandate = value[0].match(/\+|-/) !== null,
+                mandate = startWithMandate ? mandateMap[value[0]] : 'either';
+            filterSrv.set({
+              editing   : true,
+              type      : 'querystring',
+              query     : startWithMandate ? value.substr(1, value.length) : value,
+              mandate   : mandate
+            }, undefined, true);
+          }
+        });
+      }
     };
 
     $scope.remove = function(id) {

--- a/src/app/panels/filtering/module.js
+++ b/src/app/panels/filtering/module.js
@@ -44,13 +44,14 @@ function (angular, app, _) {
             var startWithMandate = value[0].match(/\+|-/) !== null,
                 mandate = startWithMandate ? mandateMap[value[0]] : 'either';
             filterSrv.set({
-              editing   : true,
+              editing   : false,
               type      : 'querystring',
               query     : startWithMandate ? value.substr(1, value.length) : value,
               mandate   : mandate
             }, undefined, true);
           }
         });
+        $scope.refresh();
       }
     };
 


### PR DESCRIPTION
eg. dashboard/#/dashboard/solr/Statistics?q=-inspireAnnex:i%20%2BinspireAnnex:ii
will setup the Statistics dashboard with 2 filters:
- inspireAnnex mustNot be i
- inspireAnnex must be ii

![image](https://cloud.githubusercontent.com/assets/1701393/6269392/2cb01f12-b853-11e4-8d88-b81091a22bd8.png)

Does it sounds like a relevant feature ?

Also I made the PR on develop branch but maybe I should move to branch dev-2.0 (as it looks to be the most active) ?
