### PR TITLE
Dashboard / Term panel / Add sort by index or count.

### DIFF
--- a/src/app/panels/terms/editor.html
+++ b/src/app/panels/terms/editor.html
@@ -7,10 +7,19 @@
     <label class="small">Length <tip>Specify a maximum number of terms to display (Top N).</tip></label>
     <input class="input-small" type="number" ng-model="panel.size" ng-change="set_refresh(true)">
   </div>
+  <div class="span2">
+    <label class="small">Sort by</label>
+    <select ng-change="set_refresh(true)" class="input-small"
+            ng-model="panel.sortBy"
+            ng-options="f for f in ['count','index']"></select>
+  </div>
   <div class="span3">
     <label class="small">Order</label>
     <!-- <select class="input-medium" ng-model="panel.order" ng-options="f for f in ['count','term','reverse_count','reverse_term']" ng-change="set_refresh(true)"></select></span> -->
-    <select class="input-medium" ng-model="panel.order" ng-options="f for f in ['descending','ascending']" ng-change="set_refresh(true)"></select>
+    <select class="input-medium"
+            ng-model="panel.order"
+            ng-options="f for f in ['descending','ascending']"
+            ng-change="set_refresh(true)"></select>
   </div>
   <div class="span4">
     <label class="small">Use field values as chart's colors <tip placement="bottom">If the field values are not valid HTML colors (either color names or hexadecimal colors), the default colors for chart will be used for the data series instead.</tip></label>

--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -56,7 +56,7 @@ function (angular, app, _, $, kbn) {
       missing : false,
       other   : false,
       size    : 10,
-      // order   : 'count',
+      sortBy  : 'count',
       order   : 'descending',
       style   : { "font-size": '10pt'},
       donut   : false,
@@ -129,7 +129,8 @@ function (angular, app, _, $, kbn) {
         // stats does not support something like facet.limit, so we have to sort and limit the results manually.
         facet = '&stats=true&stats.facet=' + $scope.panel.field + '&stats.field=' + $scope.panel.stats_field + '&facet.missing=true';;
       }
-      
+      facet += '&f.' + $scope.panel.field + '.facet.sort=' + ($scope.panel.sortBy || 'count');
+
       var exclude_length = $scope.panel.exclude.length; 
       var exclude_filter = '';
       if(exclude_length > 0){
@@ -220,11 +221,13 @@ function (angular, app, _, $, kbn) {
           });
         }
         // Sort the results
+        $scope.data = _.sortBy($scope.data, function(d) {
+          return $scope.panel.sortBy === 'index' ? d.label : d.data[0][1];
+        });
         if ($scope.panel.order === 'descending') {
-          $scope.data = _.sortBy($scope.data, function(d) {return -d.data[0][1];});
-        } else {
-          $scope.data = _.sortBy($scope.data, function(d) {return d.data[0][1];});
+          $scope.data.reverse();
         }
+
         // Slice it according to panel.size, and then set the x-axis values with k.
         $scope.data = $scope.data.slice(0,$scope.panel.size);
         _.each($scope.data, function(v) {


### PR DESCRIPTION
Using the Solr f.{{fieldName}}.facet.sort parameter allows user to sort in asc/desc order on the label (ie. index) or the count. When using a set of terms panels on the same series, it makes all histograms more readable with each others.
## Configuration

![terms-sortby-config](https://cloud.githubusercontent.com/assets/1701393/6412135/43f01348-be80-11e4-8556-3abc4b83619c.png)
## Sort by count (default)

![terms-sortby-count](https://cloud.githubusercontent.com/assets/1701393/6412136/43f26d32-be80-11e4-9615-cbf5b41732e5.png)
## Sort by label

![terms-sortby-index](https://cloud.githubusercontent.com/assets/1701393/6412137/43f48c3e-be80-11e4-835f-15960f2a347d.png)
