### PR TITLE
Dashboard / Term panel / Add color picker directive to choose colors.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "d3": "~3.5.2",
     "FileSaver": "*",
     "modernizr": "~2.8.3",
+    "chroma-js": "~0.6.1",
     "timezone-js": "~0.4.13",
     "moment": "~2.8.4",
     "bootstrap-datepicker": "~1.3.1",

--- a/src/app/components/require.config.js
+++ b/src/app/components/require.config.js
@@ -14,6 +14,7 @@ require.config({
     css:                      '../vendor/require/css',
     text:                     '../bower_components/requirejs-text/text',
     moment:                   '../bower_components/moment/moment',
+    chroma:                   '../bower_components/chroma-js/chroma',
     filesaver:                '../bower_components/FileSaver/FileSaver',
 
     angular:                  '../bower_components/angular/angular',

--- a/src/app/directives/all.js
+++ b/src/app/directives/all.js
@@ -6,5 +6,6 @@ define([
   './ngBlur',
   './ngModelOnBlur',
   './tip',
-  './confirmClick'
+  './confirmClick',
+  './colorPicker'
 ], function () {});

--- a/src/app/directives/colorPicker.js
+++ b/src/app/directives/colorPicker.js
@@ -1,0 +1,131 @@
+define([
+  'angular',
+  'app',
+  'underscore',
+  'chroma'
+],
+   function (angular, app, _, chroma) {
+    'use strict';
+
+    angular
+      .module('kibana.directives')
+      .directive('colorPicker', function () {
+        return {
+          templateUrl: 'app/partials/colorpicker.html',
+          restrict: 'A',
+          scope: {
+            colors: '=colorPicker',
+            palette: '=',
+            defaultColors: '=',
+            field: '=',
+            data: '=',
+            mode: '='
+          },
+          link: function ($scope) {
+
+            function init() {
+              // List of values with associated color
+              if (!$scope.palette) {
+                $scope.palette = [];
+              }
+              $scope.paletteValueFoundInData = true;
+              $scope.mode = $scope.mode || 'list';
+              $scope.brewer = chroma.brewer;
+              $scope.nbOfClasses = $scope.data.length || 6;
+            }
+
+
+            $scope.addValue = function () {
+              $scope.palette.push({
+                label: 'value' + $scope.palette.length,
+                color: '#FFFFFF'
+              });
+            };
+            $scope.addValuesFromIndex = function () {
+              angular.forEach($scope.data, function (item) {
+                $scope.palette.push({label: item.label, color: '#FFFFFF'});
+                item.color = '#FFFFFF';
+              });
+            };
+
+
+            $scope.removeValue = function (index) {
+              $scope.palette.splice(index, 1);
+            };
+            $scope.removeAllValues = function () {
+              $scope.palette = [];
+            };
+
+
+            // Restore to default color palette
+            // (define as directive attribute)
+            $scope.setDefault = function () {
+              $scope.colors = $scope.defaultColors;
+            };
+
+            function getColor(label) {
+              var i, item;
+              for (i = 0; i < $scope.palette.length; i + 1) {
+                item = $scope.palette[i];
+                if (item.label === label) {
+                  return item.color;
+                }
+              }
+              return null;
+            }
+
+
+            // Add or delete color property to data items
+            // based on the palette.
+            $scope.updateDataColors = function () {
+              var paletteValueFoundInData = false, i, item, color;
+              for (i = 0; i < $scope.data.length; i + 1) {
+                item = $scope.data[i];
+                color = getColor(item.label);
+                if (color === null) {
+                  delete item.color;
+                } else {
+                  item.color = color;
+                  paletteValueFoundInData = true;
+                }
+              }
+              // Display a warning if the palette describes
+              // values not in current dataset
+              $scope.paletteValueFoundInData = paletteValueFoundInData;
+            };
+
+            // Create a map of label and colors based on
+            // the selected palette.
+            $scope.createPalette = function (b) {
+              var scale = chroma.scale(b).out('hex'), i, item,
+                nbOfValues = $scope.palette.length;
+              for (i = 0; i < nbOfValues; i + 1) {
+                item = $scope.palette[i];
+                item.color = scale(1 / nbOfValues * i);
+              }
+              $scope.updateDataColors();
+            };
+
+            // Create an array of colors from the selected palette.
+            $scope.createPaletteList = function (b) {
+              var colors = [], i,
+                scale = chroma.scale(b).out('hex'),
+                nbOfValues = $scope.nbOfClasses;
+              for (i = 0; i < nbOfValues; i + 1) {
+                colors.push('"' + scale(1 / nbOfValues * i) + '"');
+              }
+              $scope.colors = colors;
+              // Reset the label/color map as both can't be defined.
+              $scope.palette = [];
+            };
+
+
+            $scope.$watchCollection('palette', $scope.updateDataColors);
+            $scope.$watch('palette.color', $scope.updateDataColors);
+
+
+            init();
+          }
+        };
+      });
+  });

--- a/src/app/directives/colorPicker.js
+++ b/src/app/directives/colorPicker.js
@@ -65,7 +65,7 @@ define([
 
             function getColor(label) {
               var i, item;
-              for (i = 0; i < $scope.palette.length; i + 1) {
+              for (i = 0; i < $scope.palette.length; i ++) {
                 item = $scope.palette[i];
                 if (item.label === label) {
                   return item.color;
@@ -79,7 +79,7 @@ define([
             // based on the palette.
             $scope.updateDataColors = function () {
               var paletteValueFoundInData = false, i, item, color;
-              for (i = 0; i < $scope.data.length; i + 1) {
+              for (i = 0; i < $scope.data.length; i ++) {
                 item = $scope.data[i];
                 color = getColor(item.label);
                 if (color === null) {
@@ -99,7 +99,7 @@ define([
             $scope.createPalette = function (b) {
               var scale = chroma.scale(b).out('hex'), i, item,
                 nbOfValues = $scope.palette.length;
-              for (i = 0; i < nbOfValues; i + 1) {
+              for (i = 0; i < nbOfValues; i ++) {
                 item = $scope.palette[i];
                 item.color = scale(1 / nbOfValues * i);
               }
@@ -111,7 +111,7 @@ define([
               var colors = [], i,
                 scale = chroma.scale(b).out('hex'),
                 nbOfValues = $scope.nbOfClasses;
-              for (i = 0; i < nbOfValues; i + 1) {
+              for (i = 0; i < nbOfValues; i ++) {
                 colors.push('"' + scale(1 / nbOfValues * i) + '"');
               }
               $scope.colors = colors;

--- a/src/app/panels/terms/editor.html
+++ b/src/app/panels/terms/editor.html
@@ -78,6 +78,11 @@
 </div>
 <div class="row">
   <div class="col-sm-12 col-md-12">
-    <label class="small">Default Colors for Chart <tip>Comma separated values of color (no quote). HTML color names or hexadecimal colors are allowed (e.g. red, #FF0000, #F00 and etc). The chart series will get a color from these color values.</tip></label><br>
-    <textarea class="input-xxlarge" type="text" ng-model="panel.chartColors" ng-list="">  &lt;/div&gt;
-&lt;/div&gt;&lt;/div&gt;</textarea></div></div>
+    <div data-color-picker="panel.chartColors"
+         palette="panel.chartColorPalette"
+         defaultColors="defaultColors"
+         mode="panel.colorMode"
+         field="panel.field"
+         data="data"/>
+  </div>
+</div>

--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -70,12 +70,15 @@ function (angular, app, _, $, kbn) {
       spyable     : true,
       show_queries:true,
       error : '',
-      chartColors : querySrv.colors
+      colorMode: 'list',
+      chartColors : querySrv.colors,
+      chartColorPalette: null
     };
     _.defaults($scope.panel,_d);
 
     $scope.init = function () {
       $scope.hits = 0;
+      $scope.defaultColors = querySrv.colors;
       $scope.testMultivalued();
       $scope.$on('refresh',function(){
         $scope.get_data();
@@ -187,10 +190,18 @@ function (angular, app, _, $, kbn) {
           }
         };
 
-        // Function for customizing chart color by using field values as colors.
+        // Function for customizing chart color by using field values as colors
+        // or by using color palette
         var addSliceColor = function(slice,color) {
           if ($scope.panel.useColorFromField && isValidHTMLColor(color)) {
             slice.color = color;
+          } else if ($scope.panel.chartColorPalette &&
+                     $scope.panel.chartColorPalette.length > 0) {
+            _.each($scope.panel.chartColorPalette, function(v) {
+              if (v.label === slice.label && isValidHTMLColor(v.color)) {
+                slice.color = v.color;
+              }
+            });
           }
           return slice;
         };
@@ -489,7 +500,6 @@ function (angular, app, _, $, kbn) {
             $tooltip.remove();
           }
         });
-
       }
     };
   });

--- a/src/app/partials/colorpicker.html
+++ b/src/app/partials/colorpicker.html
@@ -1,0 +1,147 @@
+<div>
+  <h4>Colors</h4>
+  <label class="small">
+    <input type="radio"
+           name="colorMode"
+           data-ng-model="mode"
+           id="colorModeList"
+           value="list"/>
+    <span>Comma separated values of color (no quote)</span>
+    <tip>HTML color names or hexadecimal colors are allowed
+      (e.g. red, #FF0000, #F00 and etc).
+      The chart series will get a color from these color values.</tip>
+  </label>
+  &nbsp;
+  <label class="small">
+    <input type="radio"
+           name="colorMode"
+           data-ng-model="mode"
+           id="colorModeListWithValues"
+           value="listWithValues"/>
+    <span>List of values</span>
+  </label>
+
+
+  <div data-ng-show="mode == 'list'">
+    <div class="row">
+      <div class="col-md-8">
+        <textarea class="form-control"
+                  style="width: 100%"
+              type="text"
+              data-ng-model="colors"></textarea>
+        <table style="width: 100%"><tr>
+          <td data-ng-repeat="c in colors"
+              style="background-color: {{c.substring(1, 8)}}">&nbsp;</td>
+        </tr></table>
+      </div>
+      <div class="col-md-4">
+        <span>Create a palette</span><br/>
+        <div class="input-group">
+          <input type="number"
+                 class="form-control"
+                 placeholder="Number of classes"
+                 data-ng-model="nbOfClasses"/>
+          <div class="input-group-btn">
+            <button type="button" class="btn btn-default dropdown-toggle"
+                    data-toggle="dropdown" aria-expanded="false">
+              <span>Choose a palette</span>
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu">
+              <li><a href="" data-ng-click="setDefault()">default</a></li>
+              <li data-ng-repeat="b in brewer">
+                <a href=""
+                   data-ng-click="createPaletteList(b)">
+                  <table style="width: 100%"><tr>
+                    <td data-ng-repeat="c in b"
+                        style="background-color: {{c}}">&nbsp;</td>
+                  </tr></table>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div data-ng-show="mode == 'listWithValues'">
+    <div class="row" data-ng-show="palette.length > 0">
+      <div class="col-lg-offset-6 col-lg-5">
+        <div class="btn-group pull-right">
+          <button type="button" class="btn btn-link dropdown-toggle"
+                  data-toggle="dropdown" aria-expanded="false">
+            <span>Choose a palette</span>
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu">
+            <li data-ng-repeat="b in brewer">
+              <a href=""
+                 data-ng-click="createPalette(b)">
+                <table style="width: 100%"><tr>
+                  <td data-ng-repeat="c in b"
+                          style="background-color: {{c}}">&nbsp;</td>
+                </tr></table>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="col-lg-1">
+        <button class="btn btn-link"
+                data-ng-click="removeAllValues()"
+                title="Remove all values">
+          <i class="text-danger glyphicon glyphicon-remove"/>
+        </button>
+      </div>
+    </div>
+    <div class="row"
+         data-ng-repeat="v in palette">
+      <div class="col-md-8">
+        <input type="text"
+               class="form-control"
+               name="key{{v.label}}"
+               data-ng-model="v.label"
+               data-ng-change="updateDataColors()"
+               placeholder="Index value"/>
+      </div>
+      <div class="col-md-3">
+        <div class="input-group">
+          <input type="text"
+                 class="form-control"
+                 name="color{{v.label}}"
+                 data-ng-model="v.color"
+                 data-ng-change="updateDataColors()"
+                 placeholder="Color value"/>
+          <span class="input-group-addon">
+            <input type="color"
+                   name="color{{v.color}}"
+                   data-ng-model="v.color"
+                   data-ng-change="updateDataColors()"/>
+          </span>
+        </div>
+      </div>
+      <div class="col-md-1">
+        <button class="btn btn-link"
+                data-ng-click="removeValue($index)"
+                title="Add new value">
+          <i class="text-danger glyphicon glyphicon-remove"/>
+        </button>
+      </div>
+    </div>
+
+    <button class="btn btn-link glyphicon glyphicon-plus"
+            data-ng-click="addValue()"
+            title="Add new value"/>
+    <button class="btn btn-link glyphicon glyphicon-download"
+            data-ng-disabled="!field"
+            data-ng-click="addValuesFromIndex()"
+            title="Load all values from the index field"/>
+
+    <p class="alert alert-warning"
+       data-ng-show="palette.length > 0 && !paletteValueFoundInData">
+      No values from the list are available in current data.
+    </p>
+  </div>
+
+</div>

--- a/src/bower.json
+++ b/src/bower.json
@@ -34,6 +34,7 @@
     "d3": "~3.5.2",
     "FileSaver": "*",
     "modernizr": "~2.8.3",
+    "chroma-js": "~0.6.1",
     "timezone-js": "~0.4.13",
     "moment": "~2.8.4",
     "bootstrap-datepicker": "~1.3.1",


### PR DESCRIPTION
## New dependency

Add chroma-js dependencies for easily creating palette (https://github.com/gka/chroma.js).
## User interface

Add color-picker directive which provides 2 ways of defining color palettes:
1) List of colors in a textarea (as before)

![panel-terms-color-picker-palette](https://cloud.githubusercontent.com/assets/1701393/6571438/acd6cb14-c708-11e4-81a5-3b53de76adb2.png)

2) List of colors defined for label (map of label/color)

![panel-terms-color-picker-from-list](https://cloud.githubusercontent.com/assets/1701393/6571442/aff530b0-c708-11e4-986f-b8260025f65a.png)

In mode 1, user can select a number of classes and create a list of colors from predifined palettes (or the default one).

In mode 2, user can:
- manually add label/color values one by one
- initialize the list with all labels found in the current dataset
- define color by
  - typing color code or
  - use the colorpicker (if the browser support it - HTML5 input type color)
  - or choosing one of the predefined palette.
- remove one or all values in the list
## Implementation comments

The directive could be used in other panels using the following approach:

```
 <div data-color-picker="panel.chartColors"
         palette="panel.chartColorPalette"
         defaultColors="defaultColors"
         mode="panel.colorMode"
         field="panel.field"
         data="data"/>
```

It require some work to be applied to other panels (that I'm not used too).

I was also wondering if the "Use field values as chart's colors" should be part of the color definition also to have all color related properties in the same section.
