### PR TITLE
Use POST instead of GET in Solr client to do search

### DIFF
--- a/src/vendor/solrjs/solr.js
+++ b/src/vendor/solrjs/solr.js
@@ -18498,7 +18498,10 @@
           throw new Error("No Client Set");
         }
 
-        return sjs.client.get(getRestPath('select'), queryData, successcb, errorcb);
+        // Solr select handler allows both GET and POST, but GET has a limited
+        // query string length. So, use POST to allow as long queries as needed.
+        // return sjs.client.get(getRestPath('select'), queryData, successcb, errorcb);
+        return sjs.client.post(getRestPath('select'), queryData, successcb, errorcb);
       }
     };
   };


### PR DESCRIPTION
As noted in #155, it would be better to use POST instead of GET in Solr client to do search to allow very long queries.
