### PR TITLE
Filtering panel: wrap and truncate long values to display

### DIFF
--- a/src/app/panels/filtering/module.html
+++ b/src/app/panels/filtering/module.html
@@ -15,6 +15,10 @@
     .filter-panel-filter ul {
       margin-bottom: 3px;
     }
+    .filter-values {
+      word-wrap: break-word;
+      overflow-x: hidden;
+    }
     .filter-must {
       border-bottom: #7EB26D 3px solid;
     }
@@ -59,9 +63,9 @@
 
       </div>
 
-      <div ng-hide="filterSrv.list[id].editing && isEditable(filterSrv.list[id])">
+      <div ng-hide="filterSrv.list[id].editing && isEditable(filterSrv.list[id])" class="filter-values">
         <ul class="unstyled">
-          <li ng-repeat="(key,value) in filterSrv.list[id]" ng-show="show_key(key)"><strong>{{key}}</strong> : {{value}}</li>
+          <li ng-repeat="(key,value) in filterSrv.list[id]" ng-show="show_key(key)"><strong>{{key}}</strong> : {{value | truncate}}</li>
         </ul>
       </div>
       <div ng-show="filterSrv.list[id].editing && isEditable(filterSrv.list[id])">

--- a/src/app/panels/filtering/module.js
+++ b/src/app/panels/filtering/module.js
@@ -95,6 +95,15 @@ function (angular, app, _) {
         return true;
       }
     };
+  });
 
+  module.filter('truncate', function() {
+    return function(text, length) {
+      length = length || 200;
+      if (!_.isUndefined(text) && !_.isNull(text) && text.toString().length > 0) {
+        return text.length > length ? text.substr(0,length)+'...' : text;
+      }
+      return '';
+    };
   });
 });


### PR DESCRIPTION
When a very long condition is displayed in the filtering panel, it can go out of the filter frame horizontally and/or expand the filter frame to a very big height:
![banana-filter-long-string](https://cloud.githubusercontent.com/assets/866511/6899318/5354ce14-d708-11e4-89a1-8cad1aeba5fb.png)

Fix this behavior by forcibly wrapping long values and truncating them to a limited length (200 characters each):
![banana-filter-long-string-fixed](https://cloud.githubusercontent.com/assets/866511/6899344/7c9e548e-d708-11e4-82d6-66210d7c3dc6.png)
