### PR TITLE
Fixed decoding of dashboard-object on Solr-5.0

### DIFF
--- a/src/app/services/dashboard.js
+++ b/src/app/services/dashboard.js
@@ -309,7 +309,7 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
 
           // return renderTemplate(angular.fromJson(response)._source.dashboard, $routeParams);
           // return renderTemplate(JSON.stringify(source_json.dashboard), $routeParams);
-          return renderTemplate(JSON.stringify(source_json), $routeParams);
+          return renderTemplate(source_json[0], $routeParams);
         }
       }).error(function(data, status) {
         if(status === 0) {


### PR DESCRIPTION
On Solr-5.0 source-json is an array with actual json being a string at pos(0), so omitting stringification and using the string directly for further processing. Saved dashboards(saved in solr) fail to load with solr-5.0 without this.

Don't know if the old code just works on older releases (eg. solr-4.x) or if it is broken for all versions though. Haven't tested with old solr versions.
