### PR TITLE
* Adding D3 Bar Chart Panel

### DIFF
--- a/src/app/panels/bar/d3.tip.js
+++ b/src/app/panels/bar/d3.tip.js
@@ -1,0 +1,280 @@
+// d3.tip
+// Copyright (c) 2013 Justin Palmer
+//
+// Tooltips for d3.js SVG visualizations
+
+// Public - contructs a new tooltip
+//
+// Returns a tip
+d3.tip = function() {
+  var direction = d3_tip_direction,
+      offset    = d3_tip_offset,
+      html      = d3_tip_html,
+      node      = initNode(),
+      svg       = null,
+      point     = null,
+      target    = null
+
+  function tip(vis) {
+    svg = getSVGNode(vis)
+    point = svg.createSVGPoint()
+    document.body.appendChild(node)
+  }
+
+  // Public - show the tooltip on the screen
+  //
+  // Returns a tip
+  tip.show = function() {
+    var args = Array.prototype.slice.call(arguments)
+    if(args[args.length - 1] instanceof SVGElement) target = args.pop()
+
+    var content = html.apply(this, args),
+        poffset = offset.apply(this, args),
+        dir     = direction.apply(this, args),
+        nodel   = d3.select(node), i = 0,
+        coords
+
+    nodel.html(content)
+      .style({ opacity: 1, 'pointer-events': 'all' })
+
+    while(i--) nodel.classed(directions[i], false)
+    coords = direction_callbacks.get(dir).apply(this)
+    nodel.classed(dir, true).style({
+      top: (coords.top +  poffset[0]) + 'px',
+      left: (coords.left + poffset[1]) + 'px'
+    })
+
+    return tip
+  }
+
+  // Public - hide the tooltip
+  //
+  // Returns a tip
+  tip.hide = function() {
+    nodel = d3.select(node)
+    nodel.style({ opacity: 0, 'pointer-events': 'none' })
+    return tip
+  }
+
+  // Public: Proxy attr calls to the d3 tip container.  Sets or gets attribute value.
+  //
+  // n - name of the attribute
+  // v - value of the attribute
+  //
+  // Returns tip or attribute value
+  tip.attr = function(n, v) {
+    if (arguments.length < 2 && typeof n === 'string') {
+      return d3.select(node).attr(n)
+    } else {
+      var args =  Array.prototype.slice.call(arguments)
+      d3.selection.prototype.attr.apply(d3.select(node), args)
+    }
+
+    return tip
+  }
+
+  // Public: Proxy style calls to the d3 tip container.  Sets or gets a style value.
+  //
+  // n - name of the property
+  // v - value of the property
+  //
+  // Returns tip or style property value
+  tip.style = function(n, v) {
+    if (arguments.length < 2 && typeof n === 'string') {
+      return d3.select(node).style(n)
+    } else {
+      var args =  Array.prototype.slice.call(arguments)
+      d3.selection.prototype.style.apply(d3.select(node), args)
+    }
+
+    return tip
+  }
+
+  // Public: Set or get the direction of the tooltip
+  //
+  // v - One of n(north), s(south), e(east), or w(west), nw(northwest),
+  //     sw(southwest), ne(northeast) or se(southeast)
+  //
+  // Returns tip or direction
+  tip.direction = function(v) {
+    if (!arguments.length) return direction
+    direction = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: Sets or gets the offset of the tip
+  //
+  // v - Array of [x, y] offset
+  //
+  // Returns offset or
+  tip.offset = function(v) {
+    if (!arguments.length) return offset
+    offset = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: sets or gets the html value of the tooltip
+  //
+  // v - String value of the tip
+  //
+  // Returns html value or tip
+  tip.html = function(v) {
+    if (!arguments.length) return html
+    html = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  function d3_tip_direction() { return 'n' }
+  function d3_tip_offset() { return [0, 0] }
+  function d3_tip_html() { return ' ' }
+
+  var direction_callbacks = d3.map({
+    n:  direction_n,
+    s:  direction_s,
+    e:  direction_e,
+    w:  direction_w,
+    nw: direction_nw,
+    ne: direction_ne,
+    sw: direction_sw,
+    se: direction_se
+  }),
+
+  directions = direction_callbacks.keys()
+
+  function direction_n() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.n.y - node.offsetHeight,
+      left: bbox.n.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_s() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.s.y,
+      left: bbox.s.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_e() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.e.y - node.offsetHeight / 2,
+      left: bbox.e.x
+    }
+  }
+
+  function direction_w() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.w.y - node.offsetHeight / 2,
+      left: bbox.w.x - node.offsetWidth
+    }
+  }
+
+  function direction_nw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.nw.y - node.offsetHeight,
+      left: bbox.nw.x - node.offsetWidth
+    }
+  }
+
+  function direction_ne() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.ne.y - node.offsetHeight,
+      left: bbox.ne.x
+    }
+  }
+
+  function direction_sw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.sw.y,
+      left: bbox.sw.x - node.offsetWidth
+    }
+  }
+
+  function direction_se() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.se.y,
+      left: bbox.e.x
+    }
+  }
+
+  function initNode() {
+    var node = d3.select(document.createElement('div'))
+    node.style({
+      position: 'absolute',
+      opacity: 0,
+      pointerEvents: 'none',
+      boxSizing: 'border-box'
+    })
+
+    return node.node()
+  }
+
+  function getSVGNode(el) {
+    el = el.node()
+    if(el.tagName.toLowerCase() == 'svg')
+      return el
+
+    return el.ownerSVGElement
+  }
+
+  // Private - gets the screen coordinates of a shape
+  //
+  // Given a shape on the screen, will return an SVGPoint for the directions
+  // n(north), s(south), e(east), w(west), ne(northeast), se(southeast), nw(northwest),
+  // sw(southwest).
+  //
+  //    +-+-+
+  //    |   |
+  //    +   +
+  //    |   |
+  //    +-+-+
+  //
+  // Returns an Object {n, s, e, w, nw, sw, ne, se}
+  function getScreenBBox() {
+    var targetel   = target || d3.event.target,
+        bbox       = {},
+        matrix     = targetel.getScreenCTM(),
+        tbbox      = targetel.getBBox(),
+        width      = tbbox.width,
+        height     = tbbox.height,
+        x          = tbbox.x,
+        y          = tbbox.y,
+        scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
+        scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+
+
+    point.x = x + scrollLeft
+    point.y = y + scrollTop
+    bbox.nw = point.matrixTransform(matrix)
+    point.x += width
+    bbox.ne = point.matrixTransform(matrix)
+    point.y += height
+    bbox.se = point.matrixTransform(matrix)
+    point.x -= width
+    bbox.sw = point.matrixTransform(matrix)
+    point.y -= height / 2
+    bbox.w  = point.matrixTransform(matrix)
+    point.x += width
+    bbox.e = point.matrixTransform(matrix)
+    point.x -= width / 2
+    point.y -= height / 2
+    bbox.n = point.matrixTransform(matrix)
+    point.y += height
+    bbox.s = point.matrixTransform(matrix)
+
+    return bbox
+  }
+
+  return tip
+};

--- a/src/app/panels/bar/editor.html
+++ b/src/app/panels/bar/editor.html
@@ -1,0 +1,14 @@
+<div class="row-fluid">
+    <div class="span4">
+        <label class="small">Field
+            <tip>This is the facet field.</tip>
+        </label>
+        <input type="text" class="input-small" bs-typeahead="fields.list" ng-model="panel.field" ng-change="set_refresh(true)">
+    </div>
+    <div class="span4">
+        <label class="small">Number of Bars
+            <tip>Specify a maximum number of terms/Bars to display.</tip>
+        </label>
+        <input class="input-small" type="number" ng-model="panel.size" ng-change="set_refresh(true)">
+    </div>
+</div>

--- a/src/app/panels/bar/module.html
+++ b/src/app/panels/bar/module.html
@@ -1,0 +1,54 @@
+
+<div ng-controller='bar' ng-init="init()">
+<style>
+.axis path,
+.axis line {
+  fill: none;
+  stroke: #000;
+  shape-rendering: crispEdges;
+}
+
+.d3bar {
+  font: 10px sans-serif;
+  fill: orange;
+}
+
+.d3bar:hover {
+  fill: orangered ;
+}
+
+.x.axis path {
+  display: none;
+}
+
+.d3-tip {
+  line-height: 1;
+  font-weight: bold;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  border-radius: 2px;
+}
+
+/* Creates a small triangle extender for the tooltip */
+.d3-tip:after {
+  box-sizing: border-box;
+  display: inline;
+  font-size: 10px;
+  width: 100%;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.8);
+  content: "\25BC";
+  position: absolute;
+  text-align: center;
+}
+
+/* Style northward tooltips differently */
+.d3-tip.n:after {
+  margin: -1px 0 0 0;
+  top: 100%;
+  left: 0;
+}
+</style>
+    <div bar-chart style="overflow:hidden; position:relative"></div>
+</div>

--- a/src/app/panels/bar/module.js
+++ b/src/app/panels/bar/module.js
@@ -142,6 +142,15 @@ define([
         });
       };
 
+      $scope.build_search = function(word) {
+        if(word) {
+          filterSrv.set({type:'terms',field:$scope.panel.field,value:word,mandate:'must'});
+        } else {
+          return;
+        }
+        dashboard.refresh();
+      };
+
       $scope.set_refresh = function(state) {
         $scope.refresh = state;
         // if 'count' mode is selected, set decimal_points to zero automatically.
@@ -179,14 +188,14 @@ define([
             var width = element.parent().width();
             var height = parseInt(scope.row.height);
 
-             var margin = {top: 40, right: 20, bottom: 30, left: 30};
+             var margin = {top: 40, right: 20, bottom: 60, left: 40};
               width = width - margin.left - margin.right;
               height = height - margin.top - margin.bottom;
 
               var formatPercent = d3.format(".0");
 
               var x = d3.scale.ordinal()
-                  .rangeRoundBands([10, width], .1);
+                  .rangeRoundBands([15, width], .1);
 
               var y = d3.scale.linear()
                   .range([height, 0]);
@@ -205,7 +214,7 @@ define([
                 .offset([-10, 0])
                 .html(function(d) {
                   return "<strong>Frequency:</strong> <span style='color:red'>" + d.frequency + "</span>";
-                })
+                });
 
               var svg = d3.select(element[0]).append("svg")
                   .attr("width", width + margin.left + margin.right)
@@ -221,7 +230,12 @@ define([
               svg.append("g")
                   .attr("class", "x axis")
                   .attr("transform", "translate(0," + height + ")")
-                  .call(xAxis);
+                  .call(xAxis)
+                .selectAll("text")
+                  .style("text-anchor", "end")
+                  .attr("dx", "-.8em")
+                  .attr("dy", "-.55em")
+                  .attr("transform", "rotate(-60)" );
 
               svg.append("g")
                   .attr("class", "y axis")
@@ -242,7 +256,8 @@ define([
                   .attr("y", function(d) { return y(d.frequency); })
                   .attr("height", function(d) { return height - y(d.frequency); })
                   .on('mouseover', tip.show)
-                  .on('mouseout', tip.hide);
+                  .on('mouseout', tip.hide)
+                  .on('click', function(d){ tip.hide(); scope.build_search(d.letter);});
           }
         }
       };

--- a/src/app/panels/bar/module.js
+++ b/src/app/panels/bar/module.js
@@ -1,0 +1,250 @@
+/*
+  ## D3 Bar Chart with Tooltip Integrated with Banana.
+  ## Demo URL: bl.ocks.org/Caged/6476579
+
+  ### Parameters
+  * field :: Field for Facet Query for Bar Chart Data.
+  * size :: Maximum Number of Bars.
+*/
+define([
+    'angular',
+    'app',
+    'underscore',
+    'jquery',
+    'kbn',
+    'd3',
+    './d3.tip'
+  ],
+  function(angular, app, _, $, kbn, d3) {
+    'use strict';
+
+    var module = angular.module('kibana.panels.bar', []);
+    app.useModule(module);
+
+    module.controller('bar', function($scope, querySrv, dashboard, filterSrv) {
+      $scope.panelMeta = {
+        modals: [{
+          description: "Inspect",
+          icon: "icon-info-sign",
+          partial: "app/partials/inspector.html",
+          show: $scope.panel.spyable
+        }],
+        editorTabs: [{
+          title: 'Queries',
+          src: 'app/partials/querySelect.html'
+        }],
+        status: "Experimental",
+        description: "Display the D3 Bar Chart with Tooltip."
+      };
+
+      // Set and populate defaults
+      var _d = {
+        queries: {
+          mode: 'all',
+          query: '*:*',
+          custom: ''
+        },
+        field: '',
+        size: 10,
+        spyable: true,
+        show_queries: true,
+        error: '',
+      };
+      _.defaults($scope.panel, _d);
+
+      $scope.init = function() {
+        $scope.hits = 0;
+        $scope.$on('refresh', function() {
+          $scope.get_data();
+        });
+        $scope.get_data();
+      };
+
+      $scope.get_data = function() {
+      	// Make sure we have everything for the request to complete
+        if (dashboard.indices.length === 0) {
+          return;
+        }
+        delete $scope.panel.error;
+        $scope.panelMeta.loading = true;
+        var request, results;
+
+        $scope.sjs.client.server(dashboard.current.solr.server + dashboard.current.solr.core_name);
+
+        request = $scope.sjs.Request().indices(dashboard.indices);
+        $scope.panel.queries.ids = querySrv.idsByMode($scope.panel.queries);
+
+        // Populate the inspector panel
+        $scope.inspector = angular.toJson(JSON.parse(request.toString()), true);
+
+        // Build Solr query
+        var fq = '';
+        if (filterSrv.getSolrFq() && filterSrv.getSolrFq() != '') {
+          fq = '&' + filterSrv.getSolrFq();
+        }
+        var wt_json = '&wt=json';
+        var rows_limit = '&rows=0'; // for terms, we do not need the actual response doc, so set rows=0
+        var facet = '&facet=true&facet.field=' + $scope.panel.field + '&facet.limit=' + $scope.panel.size;
+
+        // Set the panel's query
+        $scope.panel.queries.query = querySrv.getORquery() + wt_json + rows_limit + fq + facet;
+
+        // Set the additional custom query
+        if ($scope.panel.queries.custom != null) {
+          request = request.setQuery($scope.panel.queries.query + $scope.panel.queries.custom);
+        } else {
+          request = request.setQuery($scope.panel.queries.query);
+        }
+
+        results = request.doSearch();
+
+        // Populate scope when we have results
+        results.then(function(results) {
+          // Check for error and abort if found
+          if (!(_.isUndefined(results.error))) {
+            $scope.panel.error = $scope.parse_error(results.error.msg);
+            return;
+          }
+
+          var sum = 0;
+          var k = 0;
+          var missing = 0;
+          $scope.panelMeta.loading = false;
+          $scope.hits = results.response.numFound;
+          $scope.data = [];
+          $scope.maxRatio = 0;
+
+          $scope.yaxis_min = 0;
+          _.each(results.facet_counts.facet_fields, function(v) {
+            for (var i = 0; i < v.length; i++) {
+              var term = v[i];
+              i++;
+              var count = v[i];
+              sum += count;
+              if (term === null) {
+                missing = count;
+              } else {
+                // if count = 0, do not add it to the chart, just skip it
+                if (count === 0) {
+                  continue;
+                }
+                var slice = {
+                  letter: term,
+                  frequency: count                
+              	};
+                if (count / $scope.hits > $scope.maxRatio)
+                  $scope.maxRatio = count / $scope.hits
+                $scope.data.push(slice);
+              }
+            }
+          });
+          $scope.$emit('render');
+        });
+      };
+
+      $scope.set_refresh = function(state) {
+        $scope.refresh = state;
+        // if 'count' mode is selected, set decimal_points to zero automatically.
+        if ($scope.panel.mode === 'count') {
+          $scope.panel.decimal_points = 0;
+        }
+      };
+
+      $scope.close_edit = function() {
+        if ($scope.refresh) {
+          $scope.get_data();
+        }
+        $scope.refresh = false;
+        $scope.$emit('render');
+      };
+    });
+
+    module.directive('barChart', function(querySrv, dashboard, filterSrv) {
+      return {
+        restrict: 'A',
+        link: function(scope, element) {
+          // Receive render events
+          scope.$on('render', function() {
+            render_panel();
+          });
+
+          // Re-render if the window is resized
+          angular.element(window).bind('resize', function() {
+            render_panel();
+          });
+          // Function for rendering panel
+          function render_panel() {
+            element.html("");
+            var el = element[0];
+            var width = element.parent().width();
+            var height = parseInt(scope.row.height);
+
+             var margin = {top: 40, right: 20, bottom: 30, left: 30};
+              width = width - margin.left - margin.right;
+              height = height - margin.top - margin.bottom;
+
+              var formatPercent = d3.format(".0");
+
+              var x = d3.scale.ordinal()
+                  .rangeRoundBands([10, width], .1);
+
+              var y = d3.scale.linear()
+                  .range([height, 0]);
+
+              var xAxis = d3.svg.axis()
+                  .scale(x)
+                  .orient("bottom");
+
+              var yAxis = d3.svg.axis()
+                  .scale(y)
+                  .orient("left")
+                  .tickFormat(formatPercent);
+
+              var tip = d3.tip()
+                .attr('class', 'd3-tip')
+                .offset([-10, 0])
+                .html(function(d) {
+                  return "<strong>Frequency:</strong> <span style='color:red'>" + d.frequency + "</span>";
+                })
+
+              var svg = d3.select(element[0]).append("svg")
+                  .attr("width", width + margin.left + margin.right)
+                  .attr("height", height + margin.top + margin.bottom)
+                .append("g")
+                  .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+                svg.call(tip);
+
+              x.domain(scope.data.map(function(d) { return d.letter; }));
+              y.domain([0, d3.max(scope.data, function(d) { return d.frequency; })]);
+
+              svg.append("g")
+                  .attr("class", "x axis")
+                  .attr("transform", "translate(0," + height + ")")
+                  .call(xAxis);
+
+              svg.append("g")
+                  .attr("class", "y axis")
+                  .call(yAxis)
+                .append("text")
+                  .attr("transform", "rotate(-90)")
+                  .attr("y", 6)
+                  .attr("dy", ".71em")
+                  .style("text-anchor", "end")
+                  .text("Frequency");
+
+              svg.selectAll(".bar")
+                  .data(scope.data)
+                .enter().append("rect")
+                  .attr("class", "d3bar")
+                  .attr("x", function(d) { return x(d.letter); })
+                  .attr("width", x.rangeBand())
+                  .attr("y", function(d) { return y(d.frequency); })
+                  .attr("height", function(d) { return height - y(d.frequency); })
+                  .on('mouseover', tip.show)
+                  .on('mouseout', tip.hide);
+          }
+        }
+      };
+    });
+  });

--- a/src/config.js
+++ b/src/config.js
@@ -73,6 +73,7 @@ function (Settings) {
      * @type {Array}
      */
     panel_names: [
+      'bar',
       'histogram',
       'map',
       'table',


### PR DESCRIPTION
Hi,
@chrismattmann

With this request, I am proposing to **Add a Panel**, that directly integrates the Rich **D3 Bar Chart With Tool-tip**

Demo URL of the D3 Chart: http://bl.ocks.org/Caged/6476579

This Panel directly integrates the exisiting D3 Bar Chart with a Rich Layout and Tool-tip, which I believe is the most common chart for data representation. Having such a panel into Banana will add value to its Design and open opportunities for further enhancements of Panels creating a Rich User Interface for Data Visualization.

![d3 bar chart](https://cloud.githubusercontent.com/assets/8953410/7336114/cc88fbd2-eba0-11e4-9152-d8f8a4eb51b1.png)
_Fig. 1: Panel Layout (Output)_

![d3 bar settings panel](https://cloud.githubusercontent.com/assets/8953410/7336107/61bdb8f6-eba0-11e4-85a1-0a1363a29b44.png)
_Fig. 2: Panel Settings Page_
