### PR TITLE
Table panel / Add option to load important field only.

### DIFF
--- a/src/app/panels/table/fields.html
+++ b/src/app/panels/table/fields.html
@@ -11,3 +11,16 @@
       <span style="margin-left:3px" ng-click="toggle_important_field(field)" ng-repeat="field in $parent.panel.important_fields" class="label pointer remove label-default">{{field}} </span>
     </div>
   </div>
+  <div class="row">
+    <div class="col-sm-3 col-md-3">
+      <h6>
+        Load important field only
+        <tip>When the document to display contains lots of fields, it could be
+        better to only load fields to be displayed on the table and not all
+        fields in the document.</tip>
+      </h6>
+      <input type="checkbox"
+             ng-model="panel.isLoadingImportantFieldOnly"
+             ng-checked="panel.isLoadingImportantFieldOnly">
+    </div>
+  </div>

--- a/src/app/panels/table/module.js
+++ b/src/app/panels/table/module.js
@@ -78,6 +78,7 @@ function (angular, app, _, kbn, moment) {
       style   : {'font-size': '9pt'},
       overflow: 'min-height',
       fields  : [],
+      isLoadingImportantFieldOnly: false,
       important_fields : [],
       highlight : [],
       sortable: true,
@@ -267,13 +268,19 @@ function (angular, app, _, kbn, moment) {
       $scope.panel.queries.basic_query = querySrv.getORquery() + fq + sorting;
       $scope.panel.queries.query = $scope.panel.queries.basic_query + wt_json + rows_limit;
 
+      // Restrict to fields to be displayed on the table
+      if ($scope.panel.isLoadingImportantFieldOnly) {
+        var fl = "&fl=" + $scope.panel.important_fields.join(',');
+        $scope.panel.queries.query = $scope.panel.queries.query + fl;
+        $scope.panel.queries.basic_query = $scope.panel.queries.basic_query + fl;
+      }
+
       // Set the additional custom query
       if ($scope.panel.queries.custom != null) {
         request = request.setQuery($scope.panel.queries.query + $scope.panel.queries.custom);
       } else {
         request = request.setQuery($scope.panel.queries.query);
       }
-
       var results = request.doSearch();
 
       // Populate scope when we have results


### PR DESCRIPTION
When document contains lot of fields, the table panel load a lot of information that will not be displayed. This greatly improve performance for document with many (and large) fields.

Example, when a document contains an XML field:

![image](https://cloud.githubusercontent.com/assets/1701393/7607029/883e2a30-f95e-11e4-8cc2-f1c32d5d91d2.png)
