### PR TITLE
Query panel / Add reset action to set filter to *:*

### DIFF
--- a/src/app/panels/query/module.html
+++ b/src/app/panels/query/module.html
@@ -11,6 +11,7 @@
           <i class="fa fa-search pointer" ng-click="refresh()" ng-show="$last"></i>
           <!-- Remove the plus icon to disable multiple queries function -->
           <i class="fa fa-plus pointer" ng-click="querySrv.set({})" ng-show="$last"></i>
+          <i class="fa fa-eraser pointer" ng-click="reset()" ng-show="$last"></i>
         </span>
       </form>
     </div>

--- a/src/app/panels/query/module.js
+++ b/src/app/panels/query/module.js
@@ -45,6 +45,12 @@ define([
     $scope.init = function() {
     };
 
+    $scope.reset = function() {
+      $scope.querySrv.list[Object.keys($scope.querySrv.list).length - 1].
+        query = _d.query;
+      $rootScope.$broadcast('refresh');
+    };
+
     $scope.refresh = function() {
       update_history(_.pluck($scope.querySrv.list,'query'));
       $rootScope.$broadcast('refresh');


### PR DESCRIPTION
Users not used to Lucene query syntax may have difficulties to reset the filter. Add a button for that.

![image](https://cloud.githubusercontent.com/assets/1701393/7607172/9f5b87a2-f95f-11e4-8c58-09cd760fcb01.png)
