### PR TITLE
Failed to delete dashboard

### DIFF
--- a/src/vendor/solrjs/solr.js
+++ b/src/vendor/solrjs/solr.js
@@ -9001,8 +9001,8 @@
           throw new Error('ID must be set');
         }
 
-        var data = '';
-        var url = '/update?commit=true&wt=json&stream.body=<delete><query>id:"'+id+'"</query></delete>';
+        var data = 'commit=true&wt=json&stream.body=<delete><query>id:"'+id+'"</query></delete>';
+        var url = '/update';
         
         // return sjs.client.del(url, data, successcb, errorcb);
         return sjs.client.get(url, data, successcb, errorcb);


### PR DESCRIPTION
User can't delete a dashboard.
Query sent is malformed http://localhost/banana/update?commit=true&wt=json&str…elete%3E%3Cquery%3Eid:%22Full%20text%20search%22%3C/query%3E%3C/delete%3E?
with an extra ? at the end.

In https://github.com/LucidWorks/banana/blob/dev-2.0/src/vendor/solrjs/solr.js#L9005 data should not be appended to url because sjs.client.get take care of it.

Not sure that this is the best place to fix that as it's a solrjs issue.
