### PR TITLE
Term panel / Fix overlapping legend.

### DIFF
--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -464,6 +464,7 @@ function (angular, app, _, $, kbn) {
                   scope.legend = plot.getData();
                   if(!scope.$$phase) {
                     scope.$apply();
+                    render_panel();
                   }
                 });
               }


### PR DESCRIPTION
When a bar chart contains lot of series, the graph is rendered,
then angular render the legend which may be overlapping the chart.
Force a render after the legend is displayed to avoid :
![image](https://cloud.githubusercontent.com/assets/1701393/7743691/763859ba-ff9d-11e4-8ce0-e9ffcd74a4a9.png)
