### PR TITLE
Fix : Bug exclude_filter of value change to Empty value.

### DIFF
--- a/src/app/panels/terms/module.js
+++ b/src/app/panels/terms/module.js
@@ -135,7 +135,9 @@ function (angular, app, _, $, kbn) {
       var exclude_filter = '';
       if(exclude_length > 0){
         for (var i = 0; i < exclude_length; i++) {
-          exclude_filter += '&fq=-' + $scope.panel.field +":"+ $scope.panel.exclude[i];
+          if($scope.panel.exclude[i] !== "") {
+            exclude_filter += '&fq=-' + $scope.panel.field +":"+ $scope.panel.exclude[i];
+          }
         }
       }
 


### PR DESCRIPTION
Trouble generating procedure
0. default (program inside : $scope.panel.exclude array size = 0)
1. Add value to "Exclude Terms" of Terms Settings. (program inside : $scope.panel.exclude array size = 1 or more)
2. Empty "Exclude Terms". (program inside : $scope.panel.exclude array size = 1)

Although sequences should be 0, and has become one.
Therefore, it did not work properly.
