### PR TITLE
Update module.html

### DIFF
--- a/src/app/panels/map/module.html
+++ b/src/app/panels/map/module.html
@@ -59,5 +59,5 @@
         z-index: 99;
     }
   </style>
-  <div class="jvectormap" map params="{{panel}}" style="height:{{panel.height || row.height}}"></div>
+  <div class="jvectormap" map params="{{panel}}" ng-style="{height:panel.height || row.height}"></div>
 </div>


### PR DESCRIPTION
In IE 9-11 the panel height or row height is not recognized probably and therefor the default height of 20px is always set.
Changing line 62 to use ng-style instead of just style, IE is recognizing the style propably!
Tested for both IE and FF.
