### PR TITLE
add trustAsHtml function

### DIFF
--- a/src/app/panels/text/editor.html
+++ b/src/app/panels/text/editor.html
@@ -1,7 +1,7 @@
 <div>
   <div class="row">
     <div class="col-sm-4 col-md-4">
-      <label class="small">Mode</label> <select class="form-control" ng-model="panel.mode" ng-options="f for f in ['html','markdown','text']"></select>
+      <label class="small">Mode</label> <select class="form-control" ng-model="panel.mode" ng-options="f for f in ['html','trustAsHtml','markdown','text']"></select>
     </div>
     <div class="col-sm-2 col-md-2" ng-show="panel.mode == 'text'">
       <label class="small">Font Size</label> <select class="form-control" ng-model="panel.style['font-size']" ng-options="f for f in ['6pt','7pt','8pt','10pt','12pt','14pt','16pt','18pt','20pt','24pt','28pt','32pt','36pt','42pt','48pt','52pt','60pt','72pt']"></select>
@@ -10,6 +10,7 @@
 
   <label class="small">Content 
     <span ng-show="panel.mode == 'html'">(This area uses HTML sanitized via AngularJS's <a href="http://docs.angularjs.org/api/ngSanitize.$sanitize">$sanitize</a> service)</span>
+    <span ng-show="panel.mode == 'trustAsHtml'">TrustAsHtml. support CSS, Script</span>
     <span ng-show="panel.mode == 'markdown'">(This area uses <a target="_blank" href="http://en.wikipedia.org/wiki/Markdown">Markdown</a>. HTML is not supported)</span>
   </label>
   <textarea ng-model="panel.content" rows="6" style="width:95%"></textarea>

--- a/src/app/panels/text/module.html
+++ b/src/app/panels/text/module.html
@@ -6,5 +6,6 @@
   <p ng-show="panel.mode == 'text'" ng-style="panel.style" ng-bind-html="panel.content | striphtml | newlines">
   </p>
   <p ng-show="panel.mode == 'html'" ng-bind-html="panel.content">
+  <p ng-show="panel.mode == 'trustAsHtml'" ng-bind-html="panel.content | trustAsHtml"></p>
   </p>
 </div>

--- a/src/app/panels/text/module.js
+++ b/src/app/panels/text/module.js
@@ -83,4 +83,11 @@ function (angular, app, _, require) {
       }
     };
   });
+
+  module.filter('trustAsHtml',['$sce', function ($sce) {
+    return function(text) {
+      return $sce.trustAsHtml(text);
+    };
+  }]);
+
 });


### PR DESCRIPTION
original request was https://github.com/LucidWorks/banana/pull/231

Use filter instead of "ng-bind-html-unsafe"

Thanks.
