### PR TITLE
Enable search even if region is already selected in the filtering

### DIFF
--- a/src/app/panels/map/module.js
+++ b/src/app/panels/map/module.js
@@ -246,6 +246,14 @@ function (angular, app, _, $) {
     };
 
     $scope.build_search = function(field,value) {
+      var querystringObj = filterSrv.getByType("querystring");
+      _.forEach(querystringObj, function (obj) {
+        if ( obj.query.startsWith($scope.panel.field)
+            &&  obj['mandate'] == "must") {
+          filterSrv.remove(obj.id);
+        }
+      });
+
       // Set querystring to both uppercase and lowercase state values with double-quote around the value
       // to prevent query error from state=OR (Oregon)
       filterSrv.set({type:'querystring',mandate:'must',query:field+':"'+value.toUpperCase()+'" OR '+field+':"'+value.toLowerCase()+'"'});
@@ -309,9 +317,10 @@ function (angular, app, _, $) {
               },
               onRegionClick: function(event, code) {
                 var count = _.isUndefined(scope.data[code]) ? 0 : scope.data[code];
-                if (count !== 0) {
+                scope.build_search(scope.panel.field,code);
+                /*if (count !== 0) {
                   scope.build_search(scope.panel.field,code);
-                }
+                }*/
               }
             });
           });


### PR DESCRIPTION
'map' widget is inconvenient when  using filter service.

ex>
1. Choose specific region ( like California ),  filter 'querystring' is created.
2. and then no data outside CA, I can't click other region to see data.
3. Have to delete filter manually 

Here is what I change.
1. comment out count check
2. remove filter "querystring"  using same field.

Thanks.
