### PR TITLE
Add location parameter to hide toolbar and edit controls

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -135,11 +135,14 @@ function (angular, $, _, appLevelRequire) {
       .ready(function() {
         $('body').attr('ng-controller', 'DashCtrl');
         angular.bootstrap(document, apps_deps)
-          .invoke(['$rootScope', function ($rootScope) {
+          .invoke(['$rootScope', '$location', function ($rootScope, $location) {
             _.each(pre_boot_modules, function (module) {
               _.extend(module, register_fns);
             });
             pre_boot_modules = false;
+
+            $rootScope.noHeader = $location.search().noHeader !== undefined;
+            $rootScope.readonly = $location.search().readonly !== undefined;
 
             $rootScope.requireContext = appLevelRequire;
             $rootScope.require = function (deps, fn) {

--- a/src/app/directives/kibanaPanel.js
+++ b/src/app/directives/kibanaPanel.js
@@ -13,7 +13,7 @@ function (angular) {
 
         '<div class="panel-extra row"><div class="panel-extra-container col-md-12 col-xs-12">' +
 
-          '<span class="extra row-button" ng-hide="panel.draggable == false"  bs-tooltip data-trigger="hover" container="body" data-placement="top" data-title="Drag&nbsp;here&nbsp;to&nbsp;move">' +
+          '<span class="extra row-button" ng-hide="panel.draggable == false || readonly"  bs-tooltip data-trigger="hover" container="body" data-placement="top" data-title="Drag&nbsp;here&nbsp;to&nbsp;move">' +
             '<span class="row-text pointer"' +
             'data-drag=true data-jqyoui-options="{revert: \'invalid\',helper:\'clone\'}"'+
             ' jqyoui-draggable="'+
@@ -25,26 +25,26 @@ function (angular) {
               'onStop:\'panelMoveStop\''+
               '}"  ng-model="row.panels">{{panel.type}}</span>'+
           '</span>' +
-          '<span class="extra row-button" ng-show="panel.draggable == false">' +
+          '<span class="extra row-button" ng-show="panel.draggable == false && !readonly">' +
             '<span class="row-text">{{panel.type}}</span>'+
           '</span>' +
 
-          '<span class="extra row-button" ng-show="panel.editable != false">' +
+          '<span class="extra row-button" ng-show="panel.editable != false && !readonly">' +
             '<span confirm-click="row.panels = _.without(row.panels,panel)" '+
             'confirmation="Are you sure you want to remove this {{panel.type}} panel?" class="pointer">'+
             '<i class="fa fa-times pointer" bs-tooltip data-title="Remove" container="body" ></i></span>'+
           '</span>' +
 
-          '<span class="row-button extra" ng-show="panel.editable != false">' +
+          '<span class="row-button extra" ng-show="panel.editable != false && !readonly">' +
             '<span bs-modal data-content-template="app/partials/paneleditor.html" class="pointer">'+
             '<i class="fa fa-cog pointer" bs-tooltip data-title="Configure" container="body" ></i></span>'+
           '</span>' +
 
-          '<span class="row-button extra" ng-show="panel.transpose_show">' +
+          '<span class="row-button extra" ng-show="panel.transpose_show && !readonly">' +
           '<span class="rotate-icon pointer" bs-tooltip data-title="Transpose Rows and Columns" ng-click="flip()" container="body" ></span>' +
           '</span>' +
 
-          '<span ng-repeat="task in panelMeta.modals" class="row-button extra" ng-show="task.show&&panel.spyable">' +
+          '<span ng-repeat="task in panelMeta.modals" class="row-button extra" ng-show="task.show && panel.spyable && !readonly">' +
             '<span bs-modal data-content-template="{{task.partial}}" class="pointer"><i ' +
               'class="fa fa-info-circle pointer" bs-tooltip data-title="{{task.description}}" container="body" ></i></span>'+
           '</span>' +

--- a/src/app/partials/dashboard.html
+++ b/src/app/partials/dashboard.html
@@ -52,7 +52,7 @@
 
         <div ng-hide="(12-rowSpan(row)) < 1 || !dashboard.current.panel_hints" class="panel col-md-{{(12-rowSpan(row))}}" ng-class="{'dragInProgress':dashboard.panelDragging}" style="height:{{row.height}};" data-drop="true" ng-model="row.panels" data-jqyoui-options="" jqyoui-droppable="{index:row.panels.length,onDrop:'panelMoveDrop({{(12-rowSpan(row))}})',onOver:'panelMoveOver(false)',onOut:'panelMoveOut'}">
 
-          <span bs-modal="rowEditorModal" data-content-template="app/partials/roweditor.html" ng-show="row.editable &amp;&amp; !dashboard.panelDragging">
+          <span bs-modal="rowEditorModal" data-content-template="app/partials/roweditor.html" ng-show="row.editable && !dashboard.panelDragging && !readonly">
             <i ng-hide="rowSpan(row) == 0" class="pointer fa fa-plus-circle" ng-click="editor.index = 1" bs-tooltip="'Add a panel to this row'" data-placement="right"></i>
             <span ng-click="editor.index = 1" style="margin-top: 8px; margin-left: 3px" ng-show="rowSpan(row) == 0" class="btn btn-default btn-xs">Add panel to empty row
           </span>
@@ -63,7 +63,7 @@
     </div>
   </div>
 
-  <div class="row" ng-show="dashboard.current.editable">
+  <div class="row" ng-show="dashboard.current.editable && !readonly">
     <div class="col-sm-12 col-md-12">
       <span style="margin-left: 0px;float:right;margin-bottom: 20px" class="pointer btn btn-default btn-xs" bs-modal="modal" data-content-template="app/partials/dasheditor.html">
         <span ng-click="editor.index = 1"><i class="fa fa-plus-circle"></i> ADD A ROW</span>

--- a/src/app/partials/dashboard.html
+++ b/src/app/partials/dashboard.html
@@ -3,7 +3,7 @@
   <!-- Rows -->
   <div class="kibana-row row" ng-controller="RowCtrl" ng-repeat="(row_name, row) in dashboard.current.rows" ng-style="row_style(row)">
     <div class="row-control">
-      <div class="row" style="padding:0px;margin:0px;position:relative;">
+      <div class="row" style="padding:0px;margin:0px;position:relative;" data-ng-hide="readonly">
 
         <div class="row-close col-sm-12 col-md-12" ng-show="row.collapse" data-placement="bottom">
           <span class="row-button" bs-modal="rowEditorModal" data-content-template="app/partials/roweditor.html">
@@ -24,7 +24,7 @@
             <i bs-tooltip="'Configure row'" data-placement="right" container="body" class="fa fa-cog pointer"></i>
             <br>
           </span>
-          <span ng-show="rowSpan(row) == 12 &amp;&amp; row.editable">
+          <span ng-show="rowSpan(row) == 12 && row.editable">
             <i bs-tooltip="'Row full. Create a new row to add more panels'" container="body" data-placement="right" class="fa fa-trello"></i>
             <br>
           </span>

--- a/src/index.html
+++ b/src/index.html
@@ -38,7 +38,9 @@
       <span ng-bind-html="alert.text"></span>
       <div style="padding-right:10px" class="pull-right small"> {{$index + 1}} alert(s) </div>
     </div>
-    <div class="navbar navbar-default" role="navigation" bs-navbar>
+    <div class="navbar navbar-default"
+         data-ng-hide="noHeader"
+         role="navigation" bs-navbar>
       <div class="navbar-header">
         <span class="navbar-brand">
           {{dashboard.current.title}}


### PR DESCRIPTION
2 location parameters (ie. http://localhost:8993/banana/#/dashboard/solr/DASHBOARDNAME?noHeader&readonly) are added:
- noHeader : hide top toolbar
- readonly : hide editor control

eg.
![image](https://cloud.githubusercontent.com/assets/1701393/8770452/80cc2d2c-2eb2-11e5-8cc7-9d801e7165f3.png)

This mode help users embed Banana dashboards in a third party app, like a CMS using Iframe. Not sure if this may be of general interest ?
