### PR TITLE
 evol(histogram): adding SUM aggregate function

### DIFF
--- a/src/app/panels/histogram/editor.html
+++ b/src/app/panels/histogram/editor.html
@@ -24,6 +24,10 @@
       <label class="small">Group By Field <tip>This field must be a single value field. Leave blank if you do not want to group the result.</tip></label>
       <input ng-change="set_refresh(true)" placeholder="Optional" bs-typeahead="fields.list" type="text" class="input-small" ng-model="panel.group_field">
     </div>
+    <div class="span3">
+      <label class="small">SUM the group's values <tip>The point value (Y) is the sum of value field in the group</tip></label>
+      <input type="checkbox" ng-model="panel.sum_value" ng-checked="panel.sum_value">
+    </div>
     <!-- <div class="span3">
       <label class="small">Max Rows/Group <tip>Specify the number of results to return for each group.</tip></label>
       <input ng-change="set_refresh(true)" placeholder="10" type="number" class="input-small" ng-model="panel.group_limit">

--- a/src/app/panels/histogram/timeSeries.js
+++ b/src/app/panels/histogram/timeSeries.js
@@ -69,6 +69,30 @@ function (_, Interval) {
   };
 
   /**
+   * Add a row and sum the value
+   * @param {int}  time  The time for the value, in
+   * @param {any}  value The value at this time
+   */
+  ts.ZeroFilled.prototype.sumValue = function (time, value) {
+    if (time instanceof Date) {
+      time = getDatesTime(time);
+    } else {
+      time = base10Int(time);
+    }
+    if (!isNaN(time)) {
+
+      var curValue = 0;
+      if (!isNaN(this._data[time])){
+          curValue = this._data[time];
+      };
+
+
+      this._data[time] = curValue + (_.isUndefined(value) ? 0 : value);
+    }
+    this._cached_times = null;
+  };
+
+  /**
    * Get an array of the times that have been explicitly set in the series
    * @param  {array} include (optional) list of timestamps to include in the response
    * @return {array} An array of integer times.


### PR DESCRIPTION
Hi, 

Please consider this 2 évolutions / fix in histogram panel  :  
- Adding the SUM aggregate function of "value field" in the mode "values"
- View all the values in the tooltip in multiserie  in the case of an intersection

**screenshots:** 
- Histogram whitout option sum
  ![histogram_whitout_option_sum](https://cloud.githubusercontent.com/assets/14891533/10189450/6ea8bd62-6766-11e5-8bfc-2c50eee56e0d.PNG)
- Histogram with option sum and the tooltip fix
  ![histogram_option_sum](https://cloud.githubusercontent.com/assets/14891533/10189016/1aa3c812-6764-11e5-9a1c-709f7098d1a1.PNG)

![histogram_tooltip](https://cloud.githubusercontent.com/assets/14891533/10189015/1aa303dc-6764-11e5-93b1-da6d8974f993.png)
