### PR TITLE
only create mailto link for username after whitespace or line start

### DIFF
--- a/src/app/filters/all.js
+++ b/src/app/filters/all.js
@@ -66,7 +66,9 @@ define(['angular', 'jquery', 'underscore','showdown'], function(angular, $, _,Sh
       //URLs starting with "www." (without // before it, or it'd re-link the ones done above).
       r2 = /(^|[^\/])(www\.[\S]+(\b|$))/gim,
       //Change email addresses to mailto:: links.
-      r3 = /([a-zA-Z_0-9\.]+?@[a-zA-Z_0-9\.]+)/gim;
+      //only with line beginning or whitespace before it,
+      //so as not to re-link these ... ftp://user:password@host/path done above.
+      r3 = /(^|[\s])([a-zA-Z_0-9\.]+?@[a-zA-Z_0-9\.]+)/gim;
 
     var urlLink = function(text) {
       var t1,t2,t3;
@@ -82,7 +84,7 @@ define(['angular', 'jquery', 'underscore','showdown'], function(angular, $, _,Sh
         });
         text = t2 || text;
         _.each(text.match(r3), function() {
-          t3 = text.replace(r3, "<a href=\"mailto:$1\">$1</a>");
+          t3 = text.replace(r3, "$1<a href=\"mailto:$2\">$2</a>");
         });
         text = t3 || text;
         return text;


### PR DESCRIPTION
[testdata.txt](https://github.com/LucidWorks/banana/files/45521/testdata.txt)

Hi,
I came across an issue with the hyperlinks created in the table panel's Value column
I'm adding JSON documents to solr containing ftp links that include username and password
like this ...
ftp://user:password@host:21/path

I can see the code in src/app/filters/all.js, around line 65,
which first creates a hyperlink to the ftp url
but then the "password@host" part gets replaced with a "mailto:" link
which breaks the hyperlink.

I think a simple fix is to check for whitespace or line beginning before the username of a potential email address.

I tested it (with solr v 5.3.1 and banana's develop branch)
by creating a solr core based on basic_configs

$ bin/solr create_core -c bananalinkstest -d basic_configs

to which I added the test data (attached), 
then created a new non-time series dashboard in banana to look at that core
and just checked that all the links are created correctly in the table panel.

Thanks,
Frank
