### PR TITLE
Panel / range facet / alertonnonexistingstatsfield

### DIFF
--- a/src/app/panels/rangeFacet/module.js
+++ b/src/app/panels/rangeFacet/module.js
@@ -249,10 +249,6 @@ function (angular, app, $, _, kbn, moment, timeSeries) {
         var facet = $scope.sjs.DateHistogramFacet(id);
 
         if($scope.panel.mode === 'count') {
-          if (!$scope.panel.stats_field) {
-            $scope.alertInvalidField("In " + $scope.panel.mode + " mode a stats field must be specified");
-            return;
-          }
           facet = facet.field($scope.panel.time_field);
         } else {
           if(_.isNull($scope.panel.value_field)) {


### PR DESCRIPTION
RangeFacet panel / Alert when no stats_field are present but no such field exist in panel scope. Removing useless check.

![image](https://cloud.githubusercontent.com/assets/1701393/11846510/40dde368-a419-11e5-9ac5-c5c091084e7a.png)

Let me know if dev-2.0 is the correct branch to target for such fixes ?
