### PR TITLE
Fix multiple hosts issue.

### DIFF
--- a/src/app/controllers/dashLoader.js
+++ b/src/app/controllers/dashLoader.js
@@ -139,8 +139,14 @@ function (angular, _) {
       dashboard.elasticsearch_list(query,dashboard.current.loader.load_elasticsearch_size).then(
         function(result) {
         if (!_.isUndefined(result.response.docs)) {
-          $scope.hits = result.response.numFound;
-          $scope.elasticsearch.dashboards = result.response.docs;
+          var docs = [];
+          for (var i = 0; i < result.response.docs.length; i++) {
+            var doc ={};
+            doc['id'] = result.response.docs[i].id;
+            doc['server'] = angular.fromJson(result.response.docs[i].dashboard).solr.server;
+            docs.push(doc);
+          }
+          $scope.elasticsearch.dashboards = docs;
         }
       });
     };

--- a/src/app/partials/dashLoader.html
+++ b/src/app/partials/dashLoader.html
@@ -48,7 +48,7 @@
       <table class="table table-condensed table-striped">
         <tr ng-repeat="row in elasticsearch.dashboards | orderBy:['id'] | limitTo:dashboard.current.loader.load_elasticsearch_size">
           <td ng-show="dashboard.current.loader.save_elasticsearch"><a confirm-click="elasticsearch_delete(row.id)" confirmation="Are you sure you want to delete {{row.id}} dashboard?"><i class="icon-remove"></i></a></td>
-          <td><a href="#/dashboard/solr/{{row.id}}">{{row.id}}</a></td>
+          <td><a href="#/dashboard/solr/{{row.id}}?server={{row.server}}">{{row.id}}</a></td>
           <!--<td><a><i class="icon-share" ng-click="share = dashboard.share_link(row.id,'solr',row.id)" bs-modal="'app/panels/dashcontrol/share.html'"></i></a></td>-->
         </tr>
       </table>

--- a/src/app/services/dashboard.js
+++ b/src/app/services/dashboard.js
@@ -301,8 +301,9 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
     };
 
     this.elasticsearch_load = function(type,id) {
+      var server = $routeParams.server || config.solr;
       return $http({
-        url: config.solr + config.banana_index + '/select?wt=json&q=title:"' + id + '"',
+        url: server + config.banana_index + '/select?wt=json&q=title:"' + id + '"',
         method: "GET",
         transformResponse: function(response) {
           response = angular.fromJson(response);
@@ -374,14 +375,15 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
       request = type === 'temp' && ttl ? request.ttl(ttl) : request;
 
       // Solr: set sjs.client.server to use 'banana-int' for saving dashboard
-      sjs.client.server(config.solr + config.banana_index);
+      var solrserver = self.current.solr.server + config.banana_index || config.solr + config.banana_index;
+      sjs.client.server(solrserver);
 
       return request.doIndex(
         // Success
         function(result) {
           if(type === 'dashboard') {
             // TODO
-            $location.path('/dashboard/solr/'+title);
+            $location.url('/dashboard/solr/'+title+'?server='+self.current.solr.server);
           }
           return result;
         },
@@ -394,7 +396,8 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
 
     this.elasticsearch_delete = function(id) {
       // Set sjs.client.server to use 'banana-int' for deleting dashboard
-      sjs.client.server(config.solr + config.banana_index);
+      var solrserver = self.current.solr.server + config.banana_index || config.solr + config.banana_index;
+      sjs.client.server(solrserver);
 
       return sjs.Document(config.banana_index,'dashboard',id).doDelete(
         // Success

--- a/src/vendor/solrjs/solr.js
+++ b/src/vendor/solrjs/solr.js
@@ -8927,7 +8927,7 @@
             */
       doUpdate: function (successcb, errorcb) {
         // make sure the user has set a client
-        if (ejs.client == null) {
+        if (sjs.client == null) {
           throw new Error("No Client Set");
         }
         
@@ -8967,7 +8967,7 @@
           data.doc = params.source;
         }
         
-        return ejs.client.post(url, JSON.stringify(data), successcb, errorcb);
+        return sjs.client.post(url, JSON.stringify(data), successcb, errorcb);
       },
 
       /**


### PR DESCRIPTION
When start Banan and Solr to different instance (enabled CORS request in Solr), Banana settings could not save to remote Solr. Banana is always trying to access the local Solr.

For example,
Solr : localhost:8983
Banana : localhost:8081 ( Jetty + banana.war )

Screenshots,
![banana_dashboard_settings_solr](https://cloud.githubusercontent.com/assets/970948/16419461/cd76919a-3d88-11e6-9b94-aa40afa02e4c.png)
![safari_error_console](https://cloud.githubusercontent.com/assets/970948/16419475/d8adc2f4-3d88-11e6-831d-bc3e505e1bc8.png)
