### PR TITLE
- Enhanced accessibility for Banana (508)

### DIFF
--- a/src/app/controllers/dashLoader.js
+++ b/src/app/controllers/dashLoader.js
@@ -28,7 +28,7 @@ function (angular, _) {
         time_field: $scope.config.timefield
       };
     };
-    
+
     $scope.showDropdown = function(type) {
       // var _l = $scope.loader;
       var _l = dashboard.current.loader || $scope.loader;
@@ -45,9 +45,12 @@ function (angular, _) {
       if(type === 'share') {
         return (_l.save_temp);
       }
+      if(type === 'home') {
+        return (dashboard.current.home || $scope.home);
+      }
       return false;
     };
-    
+
     $scope.create_new = function(type) {
       $http.get('app/dashboards/' + type + '.json?' + new Date().getTime()).
         success(function(data) {
@@ -69,7 +72,7 @@ function (angular, _) {
           }
 
           dashboard.dash_load(data);
-          
+
           // Reset new dashboard defaults
           $scope.resetNewDefaults();
         }).

--- a/src/app/directives/kibanaPanel.js
+++ b/src/app/directives/kibanaPanel.js
@@ -32,12 +32,12 @@ function (angular) {
           '<span class="extra row-button" ng-show="panel.editable != false">' +
             '<span confirm-click="row.panels = _.without(row.panels,panel)" '+
             'confirmation="Are you sure you want to remove this {{panel.type}} panel?" class="pointer">'+
-            '<i class="icon-remove pointer" bs-tooltip="\'Remove\'"></i></span>'+
+            '<a title="Remove" alt="Remove" href="" style="color:black;" class="icon-remove pointer" bs-tooltip="\'Remove\'"></a></span>'+
           '</span>' +
 
           '<span class="row-button extra" ng-show="panel.editable != false">' +
             '<span bs-modal="\'app/partials/paneleditor.html\'" class="pointer">'+
-            '<i class="icon-cog pointer" bs-tooltip="\'Configure\'"></i></span>'+
+            '<a title="Configure" alt="Configure" href="" style="color:black;"  class="icon-cog pointer" bs-tooltip="\'Configure\'"></a></span>'+
           '</span>' +
 
           '<span class="row-button extra" ng-show="panel.transpose_show">' +
@@ -45,17 +45,17 @@ function (angular) {
           '</span>' +
 
           '<span ng-repeat="task in panelMeta.modals" class="row-button extra" ng-show="panel.spyable">' +
-            '<span bs-modal="task.partial"class="pointer"><i ' +
-              'bs-tooltip="task.description" ng-class="task.icon" class="pointer"></i></span>'+
+            '<span bs-modal="task.partial"class="pointer">' +
+            '<a title="Inspect" alt="Inspect" href="" bs-tooltip="Inspect" style="color:black;"  ng-class="task.icon" class="pointer"></a></span>'+
           '</span>' +
 
           '<span class="row-button extra" ng-show="panel.fitBoundsAuto != undefined && !panel.fitBoundsAuto">' +
-            '<a ng-click="fitBounds()"><i tooltip="\'fit bound\'" class="pointer icon-fire"></i></a>'+
+            '<a ng-click="fitBounds()"><i tooltip="\'fit bound\'" style="color:black;"  class="pointer icon-fire"></i></a>'+
           '</span>' +  // bettermap fitBound action
-            
+
           '<span class="dropdown row-button extra" bs-tooltip="\'Export\'" data-placement="bottom" ng-show="panelMeta.exportfile">' +
             '<span class="pointer" class="dropdown-toggle" data-toggle="dropdown">' +
-                '<i class="icon-save" class="pointer"></i>' +
+                '<a title="Save" alt="Save" href="" style="color:black;"  class="icon-save" class="pointer"></a>' +
             '</span>' +
             '<ul class="dropdown-menu" style="padding:10px; left:-150px;">' +
           '<h5>Number of Rows</h5><form><input type="number" value="panel.exportSize" ng-model="panel.exportSize" placeholder="{{panel.size * panel.pages}}"/>' +
@@ -63,9 +63,9 @@ function (angular) {
                 '<li>' +
                     '<h5>Export to File</h5>' +
                         '<ul class="unstyled">' +
-                            '<li><a class="link" ng-click="exportfile(\'csv\')"><i class="icon-file"></i> CSV</a></li>' +
-                            '<li><a class="link" ng-click="exportfile(\'xml\')"><i class="icon-file"></i> XML</a></li>' +
-                            '<li><a class="link" ng-click="exportfile(\'json\')"><i class="icon-file"></i> JSON</a></li>' +
+                            '<li><a class="link" title="CSV" alt="CSV" href="" ng-click="exportfile(\'csv\')"><i class="icon-file"></i> CSV</a></li>' +
+                            '<li><a class="link" title="XML" alt="XML" href="" ng-click="exportfile(\'xml\')"><i class="icon-file"></i> XML</a></li>' +
+                            '<li><a class="link" title="JSON" alt="JSON" href="" ng-click="exportfile(\'json\')"><i class="icon-file"></i> JSON</a></li>' +
                         '</ul>' +
                 '</li>' +
             '</ul>' +

--- a/src/app/panels/filtering/module.html
+++ b/src/app/panels/filtering/module.html
@@ -57,9 +57,9 @@
           <select class="input-small" ng-model="filterSrv.list[id].mandate" ng-options="f for f in ['must','mustNot','either']"></select>
         </span>
 
-        <i class="filter-action pointer icon-remove" bs-tooltip="'Remove'" ng-click="remove(id)"></i>
-        <i class="filter-action pointer" ng-class="{'icon-check': filterSrv.list[id].active,'icon-check-empty': !filterSrv.list[id].active}" bs-tooltip="'Toggle'" ng-click="toggle(id)"></i>
-        <i class="filter-action pointer icon-edit" ng-hide="filterSrv.list[id].editing" bs-tooltip="'Edit'" ng-click="filterSrv.list[id].editing = true"></i>
+        <a alt="Remove" title="Remove" href="" style="color:black;" class="filter-action pointer icon-remove" bs-tooltip="'Remove'" ng-click="remove(id)"></a>
+        <a alt="Toggle" title="Toggle" href="" style="color:black;" class="filter-action pointer" ng-class="{'icon-check': filterSrv.list[id].active,'icon-check-empty': !filterSrv.list[id].active}" bs-tooltip="'Toggle'" ng-click="toggle(id)"></a>
+        <a alt="Edit" title="Edit" href="" style="color:black;" class="filter-action pointer icon-edit" ng-hide="filterSrv.list[id].editing" bs-tooltip="'Edit'" ng-click="filterSrv.list[id].editing = true"></a>
 
       </div>
 
@@ -79,7 +79,7 @@
       </div>
     </div>
     <!-- <span bs-modal="'app/partials/paneleditor.html'" data-toggle="modal"> -->
-    <i class="pointer icon-plus-sign" ng-click="add()" bs-tooltip="'Add a query filter'" data-placement="right"></i>
+    <a alt="Add a query filter" style="color:black;" title="Add a query filter" href="" class="pointer icon-plus-sign" ng-click="add()" bs-tooltip="'Add a query filter'" data-placement="right"></a>
     <!-- </span> -->
   </div>
 </div>

--- a/src/app/panels/query/module.html
+++ b/src/app/panels/query/module.html
@@ -7,21 +7,21 @@
       </span>
       <input class="search-query panel-query" ng-class="{ 'input-block-level': unPinnedQueries.length==1, 'last-query': $last, 'has-remove': querySrv.ids.length > 1 }" bs-typeahead="panel.history" data-min-length=0 data-items=100 type="text" ng-model="querySrv.list[id].query" />
       <span class="end-query">
-        <i class="icon-search pointer" ng-click="refresh()" ng-show="$last"></i>
+        <a style="color:black;" title="Refresh" alt="Refresh" href="" class="icon-search pointer" ng-click="refresh()" ng-show="$last"></a>
         <!-- Remove the plus icon to disable multiple queries function -->
-        <i class="icon-plus pointer" ng-click="querySrv.set({})" ng-show="$last"></i>
-        <i class="icon-eraser pointer" ng-click="reset()" ng-show="$last"></i>
+        <a style="color:black;" title="New query" alt="New Query" href=""class="icon-plus pointer" ng-click="querySrv.set({})" ng-show="$last"></a>
+        <a style="color:black;" title="Erase" alt="Erase" href="" class="icon-eraser pointer" ng-click="reset()" ng-show="$last"></a>
       </span>
     </form>
   </div>
   <div style="display:inline-block" ng-repeat="id in querySrv.ids|pinnedQuery:true">
     <span class="pointer" ng-show="$first" ng-click="panel.pinned = !panel.pinned"><small class="pins">Pinned</small> <i ng-class="{'icon-caret-right':panel.pinned,'icon-caret-left':!panel.pinned}"></i></span>
     <span ng-show="panel.pinned" class="pinned badge">
-      <i class="icon-circle pointer" ng-style="{color: querySrv.list[id].color}" data-unique="1" bs-popover="'app/panels/query/meta.html'"></i><span bs-tooltip="querySrv.list[id].query"> {{querySrv.list[id].alias || querySrv.list[id].query}}</span>
+      <a class="icon-circle pointer" ng-style="{color: querySrv.list[id].color}" data-unique="1" bs-popover="'app/panels/query/meta.html'"></a><span bs-tooltip="querySrv.list[id].query"> {{querySrv.list[id].alias || querySrv.list[id].query}}</span>
     </span>
   </div>
   <span style="display:inline-block" ng-show="unPinnedQueries.length == 0">
-    <i class="icon-search pointer" ng-click="refresh()"></i>
-    <i class="icon-plus pointer" ng-click="querySrv.set({})"></i>
+    <a style="color:black;" title="Search" alt="Search" href="" bs-tooltip="'Clear Search'" class="icon-search pointer" ng-click="refresh()"></a>
+    <a style="color:black;" title="Clear Search" alt="Clear Search" bs-tooltip="'Clear Search'" href="" class="icon-plus pointer" ng-click="querySrv.set({})"></a>
   </span>
 </div>

--- a/src/app/panels/table/module.html
+++ b/src/app/panels/table/module.html
@@ -5,74 +5,95 @@
       overflow-y: auto;
       overflow-x: scroll;
     }
+    .nolink {
+      color:black;
+      text-decoration: none;
+    }
+    .nolink:focus {
+      color:#1ab2ff;
+      text-decoration: none;
+    }
+    .nolink:hover {
+      color:#1ab2ff;
+      text-decoration: none;
+    }
   </style>
   <div class="row-fluid">
     <div ng-class="{'span3':panel.field_list}" ng-show="panel.field_list">
       <div class="sidebar-nav">
-        <h5>Fields <i class=" icon-chevron-sign-left pointer " ng-click="panel.field_list = !panel.field_list" bs-tooltip="'Hide field list'" ng-show="panel.field_list"></i></h5>
+        <h5>Fields <a href="" alt="Hide Field List" class=" icon-chevron-sign-left pointer " ng-click="panel.field_list = !panel.field_list" bs-tooltip="'Hide field list'" ng-show="panel.field_list"></a></h5>
         <ul class="unstyled" style="{{panel.overflow}}:{{panel.height || row.height}};overflow-y:auto;overflow-x:hidden;">
           <li ng-style="panel.style" ng-repeat="field in fields.list" ng-show="_.isUndefined(panel.important_fields) || _.contains(panel.important_fields,field)">
-            <i class="pointer" ng-class="{'icon-check': _.contains(panel.fields,field),'icon-check-empty': !_.contains(panel.fields,field)}" ng-click="toggle_field(field)"></i>
-            <a class="pointer" data-unique="1" bs-popover="'app/panels/table/micropanel.html'" data-placement="right" ng-click="toggle_micropanel(field,true)" ng-class="{label: _.contains(panel.fields,field)}">{{facet_label(field)}}</a>
+            <a href="" title="Include Field" alt="Include Field" class="pointer" ng-class="{'icon-check': _.contains(panel.fields,field),'icon-check-empty': !_.contains(panel.fields,field)}" ng-click="toggle_field(field)"></a>
+            <a href="" title="Field Stats" alt="Field Stats" class="pointer" data-unique="1" bs-popover="'app/panels/table/micropanel.html'" data-placement="right" ng-click="toggle_micropanel(field,true)" ng-class="{label: _.contains(panel.fields,field)}">{{facet_label(field)}}</a>
           </li>
         </ul>
       </div>
     </div>
 
     <div style="{{panel.overflow}}:{{panel.height || row.height}};" ng-class="{'span9':panel.field_list,'span12':!panel.field_list}" class="table-doc-table">
-      <i class="pull-left icon-chevron-sign-right pointer" ng-click="panel.field_list = !panel.field_list" bs-tooltip="'Show field list'" ng-show="!panel.field_list"></i>
+      <a class="nolink pull-left icon-chevron-sign-right pointer" ng-click="panel.field_list = !panel.field_list" alt='Show field list' href="" bs-tooltip="'Show field list'" ng-show="!panel.field_list"></a>
 
       <div class="row-fluid" ng-show="panel.paging">
         <div class="span1 offset1" style="text-align:right">
-          <i ng-click="panel.offset = 0" ng-show="panel.offset > 0" class='icon-circle-arrow-left pointer'></i>
-          <i ng-click="panel.offset = (panel.offset - panel.size)" ng-show="panel.offset > 0" class='icon-arrow-left pointer'></i>
+          <a href="" title="Previous Page" alt="Previous Page" ng-click="panel.offset = 0" ng-show="panel.offset > 0" class='nolink icon-circle-arrow-left pointer'></a>
+          <a href="" title="Previous Page" alt="Previous Page" ng-click="panel.offset = (panel.offset - panel.size)" ng-show="panel.offset > 0" class='nolink icon-arrow-left pointer'></a>
         </div>
         <div class="span8" style="text-align:center">
           <strong ng-show="hits > 0" ng-hide="hits == 0">{{panel.offset + 1}}</strong><strong ng-show="hits == 0" ng-hide="hits > 0">{{panel.offset}}</strong> to <strong>{{dashboard.numberWithCommas(panel.offset + data.slice(panel.offset,panel.offset+panel.size).length)}}</strong>
           <small> of {{dashboard.numberWithCommas(data.length)}} available for paging</small>
         </div>
         <div class="span1" style="text-align:left">
-          <i ng-click="panel.offset = (panel.offset + panel.size)" ng-show="data.length > panel.offset+panel.size" class='icon-arrow-right pointer'></i>
+          <a href="" title="Next Page" alt="Next Page" ng-click="panel.offset = (panel.offset + panel.size)" ng-show="data.length > panel.offset+panel.size" class='nolink icon-arrow-right pointer'></a>
         </div>
       </div>
 
       <table class="table-hover table table-condensed" ng-style="panel.style">
         <thead ng-show="panel.header">
           <th ng-show="panel.fields.length<1">message (select columns from the list to the left)</th>
+          <th></th>
           <th style="white-space:nowrap" ng-repeat="field in panel.fields">
-            <i ng-show="!$first" class="pointer link icon-caret-left" ng-click="_.move(panel.fields,$index,$index-1)"></i>
-            <span  class="pointer" ng-click="set_sort(field)" ng-show='panel.sortable'>
-              {{facet_label(field)}}
-              <i ng-show='field == panel.sort[0]' class="pointer link" ng-class="{'icon-chevron-up': panel.sort[1] == 'asc','icon-chevron-down': panel.sort[1] == 'desc'}"></i>
+            <a href="" alt="Move column left" bs-tooltip="'Move column left'" ng-show="!$first" class="nolink pointer link icon-caret-left" ng-click="_.move(panel.fields,$index,$index-1)"></a>
+            <span  >
+              <a href="" alt="Sort on Column" bs-tooltip="'Sort on Column'" class="nolink pointer" ng-click="set_sort(field)" ng-show='panel.sortable'>{{facet_label(field)}} </a>
+              <a href="" alt="Sort Order {{ panel.sort[1] }}" ng-show='field == panel.sort[0]'
+                class=" nolink pointer link" ng-class="{'icon-chevron-up': panel.sort[1] == 'asc','icon-chevron-down': panel.sort[1] == 'desc'}"></a>
             </span>
             <span ng-show='!panel.sortable'>{{facet_label(field)}}</span>
-            <i ng-show="!$last" class="pointer link icon-caret-right" ng-click="_.move(panel.fields,$index,$index+1)"></i>
+            <a href="" alt="Move column right" bs-tooltip="'Move column right'" ng-show="!$last" class="nolink pointer link icon-caret-right" ng-click="_.move(panel.fields,$index,$index+1)"></a>
           </th>
           <!-- Hyperlink column header -->
           <th ng-show="panel.enableHyperlink" style="white-space:nowrap">{{panel.hyperlinkColumnHeader}}</th>
         </thead>
 
         <tbody ng-repeat="event in data | slice:panel.offset:panel.offset+panel.size" ng-class-odd="'odd'">
-          <tr ng-click="toggle_details(event)" class="pointer">
-            <td ng-show="panel.fields.length<1">{{event.kibana._source|stringify|tableTruncate:panel.trimFactor:1}}</td>
+
+          <tr ng-keypress="toggle_details(event)" ng-keydown="toggle_details(event)" ng-click="toggle_details(event)" class="pointer">
+            <td>
+              <a href="" alt="Expand Table Item" title="Expand Table Item" tabindex="0" ng-keypress="toggle_details(event)" ng-keydown="toggle_details(event)"></a>
+            </td>
+            <td ng-show="panel.fields.length<1">
+
+              {{event.kibana._source|stringify|tableTruncate:panel.trimFactor:1}}
+            </td>
 
             <!-- Table columns -->
-            <td ng-show="panel.fields.length>0" ng-repeat="field in panel.fields" ng-bind-html-unsafe="(event.kibana.highlight[field]||event.kibana._source[field]) |tableHighlight |tableTruncate:panel.trimFactor:panel.fields.length:field:panel.imageFields |tableDisplayImageField:field:panel.imageFields:panel.imgFieldWidth:panel.imgFieldHeight"></td>
+            <td ng-show="panel.fields.length>0" ng-repeat="field in panel.fields"
+              ng-bind-html-unsafe="(event.kibana.highlight[field]||event.kibana._source[field]) |tableHighlight |tableTruncate:panel.trimFactor:panel.fields.length:field:panel.imageFields |tableDisplayImageField:field:panel.imageFields:panel.imgFieldWidth:panel.imgFieldHeight"></td>
 
             <!-- Hyperlink column -->
             <td ng-click="" ng-show="panel.enableHyperlink && panel.displayLinkIcon" ng-bind-html-unsafe="event.kibana._source[panel.hyperlinkColumnForURI] |urlLinkAsIcon"></td>
             <td ng-show="panel.enableHyperlink && !panel.displayLinkIcon" ng-bind-html-unsafe="event.kibana._source[panel.hyperlinkColumnForURI] |urlLink"></td>
             <!-- end Hyperlink column -->
           </tr>
-
           <tr ng-show="event.kibana.details">
             <td colspan={{panel.fields.length}} ng-switch="event.kibana.view">
               <span>
                 View:
-                <a class="link" ng-class="{'strong':event.kibana.view == 'table'}" ng-click="event.kibana.view = 'table'">Table</a> /
-                <a class="link" ng-class="{'strong':event.kibana.view == 'json'}" ng-click="event.kibana.view = 'json'">JSON</a> /
-                <a class="link" ng-class="{'strong':event.kibana.view == 'raw'}" ng-click="event.kibana.view = 'raw'">Raw</a>
-                <i class="link pull-right icon-chevron-up" ng-click="toggle_details(event)"></i>
+                <a href="" title="JSON" alt="JSON" class="link" ng-class="{'strong':event.kibana.view == 'table'}" ng-click="event.kibana.view = 'table'">Table</a> /
+                <a href="" title="JSON" alt="JSON" class="link" ng-class="{'strong':event.kibana.view == 'json'}" ng-click="event.kibana.view = 'json'">JSON</a> /
+                <a href="" title="JSON" alt="JSON" class="link" ng-class="{'strong':event.kibana.view == 'raw'}" ng-click="event.kibana.view = 'raw'">Raw</a>
+                <a href="" title="JSON" alt="JSON" class="link pull-right icon-chevron-up" ng-click="toggle_details(event)"></a>
               </span>
               <table class='table table-bordered table-condensed' ng-switch-when="table">
                 <thead>
@@ -83,9 +104,9 @@
                 <tr ng-repeat="(key,value) in event.kibana._source" ng-class-odd="'odd'">
                   <td>{{key}}</td>
                   <td style="white-space:nowrap">
-                    <i class='icon-search pointer' ng-click="build_search(key,value)" bs-tooltip="'Add filter to match this value'"></i>
-                    <i class='icon-ban-circle pointer' ng-click="build_search(key,value,true)" bs-tooltip="'Add filter to NOT match this value'"></i>
-                    <i class="pointer icon-th" ng-click="toggle_field(key)" bs-tooltip="'Toggle table column'"></i>
+                    <a href="" alt="Filter on items where {{key}} field is {{value}}" class='nolink icon-search pointer' ng-click="build_search(key,value)" bs-tooltip="'Add filter to match this value'"></a>
+                    <a href="" alt="Filter on items where {{key}} field is not {{value}}" class='nolink icon-ban-circle pointer' ng-click="build_search(key,value,true)" bs-tooltip="'Add filter to NOT match this value'"></a>
+                    <a href="" alt="Add {{key}} field as a column" class="nolink pointer icon-th" ng-click="toggle_field(key)" bs-tooltip="'Toggle table column'"></a>
                   </td>
                   <!-- At some point we need to create a more efficient way of applying the filter pipeline -->
                   <td style="white-space:pre-wrap" ng-bind-html-unsafe="value|noXml|urlLink|stringify"></td>

--- a/src/app/panels/terms/module.html
+++ b/src/app/panels/terms/module.html
@@ -31,12 +31,23 @@
     .below{
       display: inline-block !important;
     }
-
+    .termsLegendLink {
+      color:black;
+      text-decoration: none;
+    }
+    .termsLegendLink:focus {
+      color:#1ab2ff;
+      text-decoration: none;
+    }
+    .termsLegendLink:hover {
+      color:#1ab2ff;
+      text-decoration: none;
+    }
     .leftRightLegend {
       margin-left: 10px;
-      margin-right: 10px; 
-      overflow:overlay; 
-      padding-right:10px 
+      margin-right: 10px;
+      overflow:overlay;
+      padding-right:10px
     }
     </style>
   <!-- START Pie or bar chart -->
@@ -44,14 +55,23 @@
     <!-- vertical legend above -->
     <table class="small" ng-show="panel.arrangement == 'vertical'">
       <tr ng-repeat="term in legend">
-        <td><i class="icon-circle" ng-style="{color:term.color}"></i></td> <td style="padding-right:10px;padding-left:10px;">{{term.label}}</td>
+        <td><i class="icon-circle" ng-style="{color:term.color}"></i></td>
+        <td style="padding-right:10px;padding-left:10px;">
+        <a class="termsLegendLink" href="" ng-click="build_search(term)"
+          alt="{{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}})"
+          bs-tooltip="term.label +' (' + dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points)) +')' ">
+            {{term.label}}</a> </td>
         <td>{{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}}</td>
       </tr>
     </table>
 
     <!-- horizontal legend above -->
     <div class="small" ng-show="panel.arrangement == 'horizontal'" ng-repeat="term in legend" style="float:left;padding-left: 10px;">
-      <span><i class="icon-circle" ng-style="{color:term.color}"></i> {{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}}) </span>
+      <span><i class="icon-circle" ng-style="{color:term.color}"></i>
+        <a class="termsLegendLink" href="" ng-click="build_search(term)"
+          alt="{{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}})"
+          bs-tooltip="term.label +' (' + dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points)) +')' ">
+          {{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}}) </a></span>
     </div><br>
 
   </div>
@@ -63,7 +83,12 @@
     <!-- vertical legend above -->
     <table class="small">
       <tr ng-repeat="term in legend">
-        <td><i class="icon-circle" ng-style="{color:term.color}"></i></td> <td style="padding-right:10px;padding-left:10px;">{{term.label}}</td>
+        <td><i class="icon-circle" ng-style="{color:term.color}"></i></td>
+        <td style="padding-right:10px;padding-left:10px;">
+        <a class="termsLegendLink" href="" ng-click="build_search(term)"
+          alt="{{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}})"
+          bs-tooltip="term.label +' (' + dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points)) +')' ">
+            {{term.label}}</a> </td>
         <td>{{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}}</td>
       </tr>
     </table>
@@ -75,14 +100,23 @@
     <!-- vertical legend below -->
     <table class="small" ng-show="panel.arrangement == 'vertical'">
       <tr ng-repeat="term in legend">
-        <td><i class="icon-circle" ng-style="{color:term.color}"></i></i></td> <td style="padding-right:10px;padding-left:10px;">{{term.label}}</td>
+        <td><i class="icon-circle" ng-style="{color:term.color}"></i></i></td>
+        <td style="padding-right:10px;padding-left:10px;">
+        <a class="termsLegendLink" href="" ng-click="build_search(term)"
+          bs-tooltip="term.label +' (' + dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points)) +')' "
+          alt="{{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}})">
+            {{term.label}}</a> </td>
         <td>{{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}}</td>
       </tr>
     </table>
 
     <!-- horizontal legend below -->
     <div class="small" ng-show="panel.arrangement == 'horizontal'" ng-repeat="term in legend" style="float:left;padding-left: 10px;">
-      <span><i class="icon-circle" ng-style="{color:term.color}"></i> {{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}}) </span>
+      <span><i class="icon-circle" ng-style="{color:term.color}"></i>
+         <a class="termsLegendLink" href="" ng-click="build_search(term)"
+          bs-tooltip="term.label +' (' + dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points)) +')' "
+          alt="{{term.label}} ({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}})">
+            {{term.label}}</a>({{dashboard.numberWithCommas(term.data[0][1].toFixed(panel.decimal_points))}}) </span>
     </div><br>
 
   </div>
@@ -101,8 +135,13 @@
       <td>{{term.data[0][1].toFixed(panel.decimal_points)}}</td>
       <td>
         <span ng-hide="term.meta == 'other'">
-          <i class='icon-search pointer' ng-click="build_search(term)"></i>
-          <i class='icon-ban-circle pointer' ng-click="build_search(term,true)"></i>
+          <a href=""
+          alt="Filter on {{term.label}} with {{term.data[0][1].toFixed(panel.decimal_points)}} items"
+          style="color:black;" class='icon-search pointer' ng-click="build_search(term)"></a>
+
+          <a href=""
+          alt="Exclude {{term.label}} with {{term.data[0][1].toFixed(panel.decimal_points)}} items"
+          style="color:black;" class='icon-ban-circle pointer' ng-click="build_search(term,true)"></a>
         </span>
       </td>
     </tr>

--- a/src/app/panels/timepicker/module.html
+++ b/src/app/panels/timepicker/module.html
@@ -56,13 +56,13 @@
   </div>
   <div class="row-fluid nomargin">
     <div class="span12 small" ng-show="filterSrv.idsByType('time').length > 0">
-      <a class="link" ng-click="set_mode('relative')" ng-class="{'strong': (panel.mode == 'relative')}">Relative</a> |
-      <a class="link" ng-click="set_mode('absolute')" ng-class="{'strong': (panel.mode == 'absolute')}">Absolute</a> |
-      <a class="link" ng-click="set_mode('since')"    ng-class="{'strong': (panel.mode == 'since')}">Since</a>
+      <a title="Relative" alt="Relative" href="" class="link" ng-click="set_mode('relative')" ng-class="{'strong': (panel.mode == 'relative')}">Relative</a> |
+      <a title="Absolute" alt="Absolute" href="" class="link" ng-click="set_mode('absolute')" ng-class="{'strong': (panel.mode == 'absolute')}">Absolute</a> |
+      <a title="Since" alt="Since" href="" class="link" ng-click="set_mode('since')"    ng-class="{'strong': (panel.mode == 'since')}">Since</a>
       <span ng-hide="panel.mode == 'absolute' || panel.mode == 'none'"> |
         <input type="checkbox" ng-model="panel.refresh.enable" ng-change='refresh();'> Auto-refresh
         <span ng-class="{'ng-cloak': !panel.refresh.enable}">
-          every <a data-title="<small>Auto-refresh Settings</small>" data-placement="bottom" bs-popover="'app/panels/timepicker/refreshctrl.html'">{{panel.refresh.interval}}s</a>.
+          every <a href="" title="Refresh Interval" alt="Refresh Inverval" data-title="<small>Auto-refresh Settings</small>" data-placement="bottom" bs-popover="'app/panels/timepicker/refreshctrl.html'">{{panel.refresh.interval}}s</a>.
         </span>
       </span>
     </div>

--- a/src/app/partials/dashLoader.html
+++ b/src/app/partials/dashLoader.html
@@ -1,20 +1,20 @@
 <!-- This file is responsible for nav bar of the dashboard -->
 <li class="dropdown" bs-tooltip="'Collections'" data-placement="bottom" style="padding-top:5px;" ng-show="dashboard.current.loader.dropdown_collections"><select class="span2" ng-model="dashboard.current.solr.core_name" ng-change="dashboard.refresh()" ng-options="c as c for c in dashboard.current.solr.core_list"></select></li>
 
-<li><a bs-tooltip="'Goto saved default'" data-placement="bottom" href='#/dashboard'><i class='icon-home'></i></a></li>
+<li ng-show="showDropdown('home')" ><a href="" alt="Goto saved default" title="Goto saved default" bs-tooltip="'Goto saved default'" data-placement="bottom" href='#/dashboard'><i class='icon-home'></i></a></li>
 <!-- New menu -->
 <li class="dropdown" bs-tooltip="'New'" data-placement="bottom" ng-show="showDropdown('new')" >
-  <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+  <a href="#" alt="New" title="New"   class="dropdown-toggle" data-toggle="dropdown">
     <i class='icon-file'></i>
   </a>
   <ul class="dropdown-menu" style="padding:10px">
-    <li><a class="link" bs-modal="'app/partials/solrSettings.html'" ng-click="$scope.type='default-ts'"><i class="icon-time"></i> Time-series dashboard </a></li>
-    <li><a class="link" bs-modal="'app/partials/solrSettings.html'" ng-click="$scope.type='default-nts'"><i class="icon-th-large"></i> Non time-series dashboard </a></li>
+    <li><a href="" alt="Time-series dashboard" title="Time-series dashboard" class="link" bs-modal="'app/partials/solrSettings.html'" ng-click="$scope.type='default-ts'"><i class="icon-time"></i> Time-series dashboard </a></li>
+    <li><a href="" alt="Non time-series dashboard" title="Non time-series dashboard" class="link" bs-modal="'app/partials/solrSettings.html'" ng-click="$scope.type='default-nts'"><i class="icon-th-large"></i> Non time-series dashboard </a></li>
   </ul>
 </li>
 <!-- Load menu -->
 <li class="dropdown" bs-tooltip="'Load'" data-placement="bottom" ng-show="showDropdown('load')" >
-  <a href="#" class="dropdown-toggle" data-toggle="dropdown" ng-click="elasticsearch_dblist('title:'+elasticsearch.query+'*')">
+  <a href="" alt="Load" title="Load" href="#" class="dropdown-toggle" data-toggle="dropdown" ng-click="elasticsearch_dblist('title:'+elasticsearch.query+'*')">
     <i class='icon-folder-open'></i>
   </a>
   <ul class="dropdown-menu" style="padding:10px;z-index:1001">
@@ -57,16 +57,16 @@
 </li>
 <!-- Save menu -->
 <li class="dropdown" bs-tooltip="'Save'" data-placement="bottom" ng-show="showDropdown('save')">
-  <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+  <a alt="Save" title="Save" href="#" class="dropdown-toggle" data-toggle="dropdown">
     <i class='icon-save'></i>
   </a>
   <ul class="dropdown-menu" style="padding:10px">
     <li ng-show="dashboard.current.loader.save_default || dashboard.current.loader.save_local">
       <h5>Locally</h5>
       <ul class="unstyled">
-        <li ng-show="dashboard.current.loader.save_local"><a class="link" ng-click="dashboard.to_file()"><i class="icon-download"></i> Export to File</a> <tip>Export layout, not data, to file</tip></li>
-        <li ng-show="dashboard.current.loader.save_default"><a class="link" ng-click="set_default()"><i class="icon-bookmark"></i> Set as Browser Default</a> <tip>Store dashboard preference to browser's localStorage</tip></li>
-        <li ng-show="dashboard.current.loader.save_default"><a class="link" ng-click="purge_default()"><i class="icon-ban-circle"></i> Clear Browser Default</a></li>
+        <li ng-show="dashboard.current.loader.save_local"><a href="" alt="Export to File" title="Export to File" class="link" ng-click="dashboard.to_file()"><i class="icon-download"></i> Export to File</a> <tip>Export layout, not data, to file</tip></li>
+        <li ng-show="dashboard.current.loader.save_default"><a href="" alt="Set as Browser Default" title="Set as Browser Default" class="link" ng-click="set_default()"><i class="icon-bookmark"></i> Set as Browser Default</a> <tip>Store dashboard preference to browser's localStorage</tip></li>
+        <li ng-show="dashboard.current.loader.save_default"><a href="" alt="Export to File" title="Export to File" class="link" ng-click="purge_default()"><i class="icon-ban-circle"></i> Clear Browser Default</a></li>
       </ul>
     </li>
     <li ng-show="dashboard.current.loader.save_gist">
@@ -82,10 +82,10 @@
       <h5>Solr</h5>
       <form class="input-append">
         <input class='input-medium' placeholder="{{dashboard.current.title}}" type="text" ng-model="elasticsearch.title"/>
-        <button class="btn" ng-click="elasticsearch_save('dashboard', null)"><i class="icon-save"></i></button>
+        <button class="btn" alt="Save to Solr" title="Save to Solr" ng-click="elasticsearch_save('dashboard', null)"><i class="icon-save"></i></button>
       </form>
     </li>
   </ul>
 </li>
 <!-- Configure menu -->
-<li ng-show="dashboard.current.editable "bs-tooltip="'Configure dashboard'" data-placement="bottom"><a href='#' bs-modal="'app/partials/dasheditor.html'"><i class='icon-cog pointer'></i></a></li>
+<li ng-show="dashboard.current.editable "bs-tooltip="'Configure dashboard'" data-placement="bottom"><a title="Configuration" alt="Configuration" href='#' bs-modal="'app/partials/dasheditor.html'"><i class='icon-cog pointer'></i></a></li>

--- a/src/app/partials/dashboard.html
+++ b/src/app/partials/dashboard.html
@@ -1,5 +1,18 @@
 <div class="row-fluid container" style="margin-top:10px; width:98%">
-
+<style>
+  .nolink {
+    color:black;
+    text-decoration: none;
+  }
+  .nolink:focus {
+    color:#1ab2ff;
+    text-decoration: none;
+  }
+  .nolink:hover {
+    color:#1ab2ff;
+    text-decoration: none;
+  }
+</style>
   <!-- Rows -->
   <div class="row-fluid kibana-row" ng-controller="RowCtrl" ng-repeat="(row_name, row) in dashboard.current.rows" ng-style="row_style(row)">
     <div class="row-control">
@@ -7,25 +20,25 @@
 
         <div class="row-close span12" ng-show="row.collapse" data-placement="bottom" >
           <span class="row-button" bs-modal="'app/partials/roweditor.html'" class="pointer">
-            <i bs-tooltip="'Configure row'" data-placement="right" ng-show="row.editable" class="icon-cog pointer"></i>
+            <a href="" title="Configure Row" alt="Configure Row" bs-tooltip="'Configure row'" style="color:black;" data-placement="right" ng-show="row.editable" class="nolink small icon-cog pointer"></a>
           </span>
           <span class="row-button" ng-click="toggle_row(row)" ng-show="row.collapsable">
-            <i bs-tooltip="'Expand row'" data-placement="right" ng-show="row.editable" class="icon-expand pointer" ></i>
+            <a alt="Expand row" bs-tooltip="'Expand row'" data-placement="right" ng-show="row.editable" class="nolink small icon-expand pointer" ></a>
           </span>
           <span class="row-button row-text" ng-click="toggle_row(row)" ng-class="{'pointer':row.collapsable}">{{row.title || 'Row '+$index}}</span>
         </div>
 
         <div style="text-align:left" class="row-open" ng-show="!row.collapse">
           <span ng-show="row.collapsable">
-            <i bs-tooltip="'Hide row'" data-placement="right"  class="icon-collapse-top" ng-click="toggle_row(row)"></i>
+            <a href="" bs-tooltip="'Hide row'" data-placement="right"  class="nolink small icon-collapse-top" ng-click="toggle_row(row)"></a>
             <br>
           </span>
           <span bs-modal="'app/partials/roweditor.html'" ng-show="row.editable">
-            <i bs-tooltip="'Configure row'" data-placement="right"  class="icon-cog pointer"></i>
+            <a href="" title="Configure Row" alt="Configure Row"  bs-tooltip="'Configure row'" data-placement="right" class="nolink small icon-cog pointer"></a>
             <br>
           </span>
           <span ng-show="rowSpan(row) == 12 && row.editable">
-            <i bs-tooltip="'Row full. Create a new row to add more panels'" data-placement="right" class="icon-trello"></i>
+            <a href="" alt='Row Full' bs-tooltip="'Row full. Create a new row to add more panels'" data-placement="right" class="nolink small icon-trello"></a>
             <br>
           </span>
           <span ng-show="rowSpan(row) > 12">

--- a/src/app/partials/dasheditor.html
+++ b/src/app/partials/dasheditor.html
@@ -15,6 +15,9 @@
         <label class="small"> Editable </label><input type="checkbox" ng-model="dashboard.current.editable" ng-checked="dashboard.current.editable" />
       </div>
       <div class="span1">
+        <label class="small"> Home </label><input type="checkbox" ng-model="dashboard.current.home" ng-checked="dashboard.current.home" />
+      </div>
+      <div class="span1">
         <label class="small"> Hints <tip>Show 'Add panel' hints in empty spaces</tip></label><input type="checkbox" ng-model="dashboard.current.panel_hints" ng-checked="dashboard.current.panel_hints" />
       </div>
       <div class="span3">

--- a/src/app/services/dashboard.js
+++ b/src/app/services/dashboard.js
@@ -23,6 +23,7 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
       title: "",
       style: "dark",
       editable: true,
+      home: true,
       failover: false,
       panel_hints: true,
       rows: [],

--- a/src/index.html
+++ b/src/index.html
@@ -2,8 +2,9 @@
   <!--[if IE 8]>         <html class="no-js lt-ie9" lang="en"> <![endif]-->
   <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
   <head>
+  <script src="vendor/xhr-xdr-adapter.js" type="text/javascript"></script>
+   <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE; chrome=1" />
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width">
 
     <title>Banana 3</title>

--- a/src/vendor/xhr-xdr-adapter.js
+++ b/src/vendor/xhr-xdr-adapter.js
@@ -1,0 +1,272 @@
+/*
+
+ xhr-xdr-adapter
+
+ Use XDomainRequest on IE 8 and IE 9 for cross-origin requests only.
+ Default to standard XMLHttpRequest otherwise.
+
+ Include this file on IE 8 & 9 before making cross-origin ajax requests
+ using libraries or frameworks such as jQuery or AngularJS.  This will allow
+ you to do things like AJAX GET templates/assets from a CDN at run time using
+ the standard XMLHttpRequest API on IE 8/9, or do simple cross-domain POSTs.
+
+ But it doesn't get around the basic limitations of IE 8 & 9's XDomainRequest:
+ * No authentication or cookies can be sent
+ * POST or GET only
+ * No custom headers can be sent
+ * text/plain contentType only
+
+
+ The MIT License (MIT)
+
+ Copyright (c) 2014 Intuit Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+(function () {
+    "use strict";
+    // Ignore everything below if not on IE 8 or IE 9.
+    if (!window.XDomainRequest) {  // typeof XDomainRequest is 'object' in IE 8, 'function' in IE 9
+        return;
+    }
+    if ('withCredentials' in new window.XMLHttpRequest()) {
+        return;
+    }
+    if (window.XMLHttpRequest.supportsXDR === true) {
+        // already set up
+        return;
+    }
+
+    var OriginalXMLHttpRequest = window.XMLHttpRequest;
+    var urlRegEx = /^([\w.+-]+:)(?:\/\/([^\/?#:]*)(?::(\d+)|)|)/;
+    var httpRegEx = /^https?:\/\//i;
+    var getOrPostRegEx = /^get|post$/i;
+    var sameSchemeRegEx = new RegExp('^' + location.protocol, 'i');
+
+    // Determine whether XDomainRequest should be used for a given request
+    var useXDR = function (method, url, async) {
+        var remoteUrl = url;
+        var baseHref;
+        var myLocationParts;
+        var remoteLocationParts;
+        var crossDomain;
+		
+		
+        try {
+            // account for the possibility of a <base href="..."> setting, which could make a URL that looks relative actually be cross-domain
+            if ((remoteUrl && remoteUrl.indexOf("://") < 0) && document.getElementsByTagName('base').length > 0) {
+                baseHref = document.getElementsByTagName('base')[0].href;
+                if (baseHref) {
+                    remoteUrl = baseHref + remoteUrl;
+                }
+            }
+
+            myLocationParts = urlRegEx.exec(location.href);
+            remoteLocationParts = urlRegEx.exec(remoteUrl);
+            crossDomain = (myLocationParts[2].toLowerCase() !== remoteLocationParts[2].toLowerCase());
+
+            // XDomainRequest can only be used for async get/post requests across same scheme, which must be http: or https:
+            return crossDomain && async && getOrPostRegEx.test(method) && httpRegEx.test(remoteUrl) && sameSchemeRegEx.test(remoteUrl);
+        }
+        catch (ex) {
+			//console.log("Exception in useXDR dump: ");
+			//console.log (crossDomain && async && getOrPostRegEx.test(method) && httpRegEx.test(remoteUrl) && sameSchemeRegEx.test(remoteUrl));
+			//console.log("end useXDR dump");
+            return false;
+        }
+    };
+
+    window.XMLHttpRequest = function () {
+        var self = this;
+        this._setReadyState = function (readyState) {
+            if (self.readyState !== readyState) {
+                self.readyState = readyState;
+                if (typeof self.onreadystatechange === "function") {
+                    self.onreadystatechange();
+                }
+            }
+        };
+        this.readyState = 0;
+        this.responseText = "";
+        this.status = 0;
+        this.statusText = "";
+        this.withCredentials = false;
+    };
+
+    window.XMLHttpRequest.prototype.open = function (method, url, async) {
+        var self = this;
+        var request;
+
+        if (useXDR(method, url, async)) {
+            // Use XDR
+            request = new XDomainRequest();
+            request._xdr = true;
+            request.onerror = function () {
+                self.status = 400;
+                self.statusText = "Error";
+                self._setReadyState(0);
+                if (self.onerror) {
+                    self.onerror();
+                }
+            };
+            request.ontimeout = function () {
+                self.status = 408;
+                self.statusText = "Timeout";
+                self._setReadyState(2);
+                if (self.ontimeout) {
+                    self.ontimeout();
+                }
+            };
+            request.onload = function () {
+                self.responseText = request.responseText;
+                self.status = 200;
+                self.statusText = "OK";
+                self._setReadyState(4);
+                if (self.onload) {
+                    self.onload();
+                }
+            };
+            request.onprogress = function () {
+                if (self.onprogress) {
+                    self.onprogress.apply(self, arguments);
+                }
+            };
+			//console.log("Using XDR");
+        }
+
+        else {
+            // Use standard XHR
+            request = new OriginalXMLHttpRequest();
+			
+            request.withCredentials = this.withCredentials;
+            request.onreadystatechange = function () {
+                if (request.readyState === 4) {
+                    self.status = request.status;
+                    self.statusText = request.statusText;
+                    self.responseText = request.responseText;
+                    self.responseXML = request.responseXML;
+                }
+                self._setReadyState(request.readyState);
+            };
+            request.onabort = function () {
+                if (self.onabort) {
+                    self.onabort.apply(self, arguments);
+                }
+            };
+            request.onerror = function () {
+                if (self.onerror) {
+                    self.onerror.apply(self, arguments);
+                }
+            };
+            request.onload = function () {
+                if (self.onload) {
+                    self.onload.apply(self, arguments);
+                }
+            };
+            request.onloadend = function () {
+                if (self.onloadend) {
+                    self.onloadend.apply(self, arguments);
+                }
+            };
+            request.onloadstart = function () {
+                if (self.onloadstart) {
+                    self.onloadstart.apply(self, arguments);
+                }
+            };
+            request.onprogress = function () {
+                if (self.onprogress) {
+                    self.onprogress.apply(self, arguments);
+                }
+            };
+			//console.log("using XHR");
+        }
+
+        this._request = request;
+        request.open.apply(request, arguments);
+	
+        this._setReadyState(1);
+    };
+
+    window.XMLHttpRequest.prototype.abort = function () {
+        this._request.abort();
+        this._setReadyState(0);
+        this.onreadystatechange = null;
+    };
+
+    window.XMLHttpRequest.prototype.send = function (body) {
+        var self = this;
+        this._request.withCredentials = this.withCredentials;
+
+        if (this._request._xdr) {
+            setTimeout(function () {
+                self._request.send(body);
+            }, 0);
+        }
+        else {
+            this._request.send(body);
+        }
+
+        if (this._request.readyState === 4) {
+            // when async==false the browser is blocked until the transfer is complete and readyState becomes 4
+            // onreadystatechange should not get called in this case
+            this.status = this._request.status;
+            this.statusText = this._request.statusText;
+            this.responseText = this._request.responseText;
+            this.readyState = this._request.readyState;
+        }
+        else {
+            this._setReadyState(2);
+        }
+    };
+
+    window.XMLHttpRequest.prototype.setRequestHeader = function () {
+        if (this._request.setRequestHeader) {
+            this._request.setRequestHeader.apply(this._request, arguments);
+        }
+    };
+
+    window.XMLHttpRequest.prototype.getAllResponseHeaders = function () {
+        if (this._request.getAllResponseHeaders) {
+            return this._request.getAllResponseHeaders();
+        }
+        else {
+            return ("Content-Length: " + this.responseText.length +
+                "\r\nContent-Type:" + this._request.contentType);
+        }
+    };
+
+    window.XMLHttpRequest.prototype.getResponseHeader = function (header) {
+        if (this._request.getResponseHeader) {
+            return this._request.getResponseHeader.apply(this._request, arguments);
+        }
+        if (typeof  header !== "string") {
+            return;
+        }
+        header = header.toLowerCase();
+        if (header === "content-type") {
+            return this._request.contentType;
+        }
+        else if (header === "content-length") {
+            return this.responseText.length;
+        }
+    };
+
+    window.XMLHttpRequest.supportsXDR = true;
+})();


### PR DESCRIPTION
Please accept the pull request to improve Banana 508 accessibility compliance; courtesy of General Services Administration - FAS unit. 
- Replaced many `<i>`attributes with`<a>` with added alt and title tags where appropriate. This is needed to tab through elements. 
- All Banana panel headings and several panels are now tabbable, allowing a user to navigate the dashboard with only the keyboard.
- The terms panel legend has been modified with an alt attribute that  contains the data for screen reader. Additionally, the items in the legend are now clickable and add a filter. This helps accessibility and also resolves the issue of sometimes having a bar chart or a pie slice that is too small and awkward to click on.
- Added a new dashboard configuration parameter that toggles the Home button. This is useful if you want to lock down the dashboard to remove nav elements.
- Added xhr-xdr-adapter to improve internet explorer compatibility. 

This is till not 100% implemented for all panels, but over the next few weeks I will be working on improving accessibility in several other panels like the table panel and facets. Overall; I think this can be one of the most accessible data visualization tools around. 
