### PR TITLE
Add build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project name="banana" basedir="." default="build-war" xmlns:ivy="antlib:org.apache.ivy.ant" xmlns:artifact="antlib:org.apache.maven.artifact.ant">
+
+  <property name="src.dir" value="${basedir}/src" />
+  <property name="build.dir" value="${basedir}/build" />
+
+  <property name="name" value="banana" />
+  <exec executable="jq" outputproperty="version" failonerror="true" failifexecutionfails="true">
+    <arg line="-r '.version' ${basedir}/package.json" />
+  </exec>
+  <property name="final.name" value="${name}-${version}" />
+
+  <!-- define Maven coordinates, repository url and artifacts name etc -->
+  <property name="groupId" value="com.lucidworks" />
+  <property name="artifactId" value="${final.name}" />
+  <property name="maven-repository-url"
+    value="https://oss.sonatype.org/service/local/staging/deploy/maven2" />
+  <property name="maven-repository-id" value="sonatype-nexus-staging" />
+  <property name="maven-war" value="${build.dir}/${final.name}.war" />
+
+  <target name="build-war" description="Build application as a WAR file">
+    <war destfile="${build.dir}/${final.name}.war" webxml="${src.dir}/WEB-INF/web.xml">
+      <fileset dir="${src.dir}">
+        <include name="**/*.*" />
+      </fileset>
+    </war>
+  </target>
+
+  <!-- ================================================================== -->
+  <!-- Deploy to SonaType OSSRH -->
+  <!-- ================================================================== -->
+  <target name="deploy" depends="build-war" description="Deploy to SonaType OSSRH">
+    <!-- sign and deploy the war artifact -->
+    <artifact:mvn>
+      <arg
+        value="org.apache.maven.plugins:maven-gpg-plugin:1.5:sign-and-deploy-file" />
+      <arg value="-Durl=${maven-repository-url}" />
+      <arg value="-DrepositoryId=${maven-repository-id}" />
+      <arg value="-DpomFile=pom.xml" />
+      <arg value="-Dfile=${maven-war}" />
+      <arg value="-Prelease" />
+    </artifact:mvn>
+  </target>
+</project>
+


### PR DESCRIPTION
The README.txt says the following.
https://github.com/lucidworks/banana#option-3-building-and-installing-from-a-war-file

```
Run a command line "ant" from within the banana directory to build the war file:

    cd $BANANA_REPO_HOME
    ant
```

However, build.xml does not exist. I propose to add build.xml for build WAR file to ease.
