### PR TITLE
Remove usage of eval in src/vendor/timezone.js

### DIFF
--- a/src/vendor/timezone.js
+++ b/src/vendor/timezone.js
@@ -881,7 +881,6 @@
     };
     this.loadZoneJSONData = function (url, sync) {
       var processData = function (data) {
-        console.log('testinig timiezone security fix');
         data = JSON.parse(data);
         for (var z in data.zones) {
           _this.zones[z] = data.zones[z];

--- a/src/vendor/timezone.js
+++ b/src/vendor/timezone.js
@@ -881,7 +881,8 @@
     };
     this.loadZoneJSONData = function (url, sync) {
       var processData = function (data) {
-        data = eval('('+ data +')');
+        console.log('testinig timiezone security fix');
+        data = JSON.parse(data);
         for (var z in data.zones) {
           _this.zones[z] = data.zones[z];
         }


### PR DESCRIPTION
## Details
_Testing of this PR is currently in progress, please do not merge_

The presence of `eval` in `timezone.js` was flagged as a security vulnerability by a static analysis tool (veracode was used to flag this, and this fix is tested on SonarQube). This is an attempt to fix this by moving to `JSON.parse(data)` instead.

vulnerability: [CWE-95](https://cwe.mitre.org/data/definitions/95.html)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval mentions using `Function()` instead of `eval`. However, `Function` is also flagged as an OWASP Top 10 Category A1 injection issue 😂 

## Screenshots
Issue raised:
  <img width="997" alt="Screen Shot 2019-12-11 at 8 30 48 AM" src="https://user-images.githubusercontent.com/6275470/70640253-8a9f0600-1bf0-11ea-99c1-e44aadd1c8a9.png">
